### PR TITLE
Add serialization groups

### DIFF
--- a/src/AnnotationGenerator/SerializerGroupsAnnotationGenerator.php
+++ b/src/AnnotationGenerator/SerializerGroupsAnnotationGenerator.php
@@ -1,12 +1,10 @@
 <?php
 
 /*
- * This file is part of the schema-generator.
+ * (c) Kévin Dunglas <dunglas@gmail.com>
  *
- * (c) Youssef El Montaser <youssef@elmontaser.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
 namespace ApiPlatform\SchemaGenerator\AnnotationGenerator;

--- a/src/AnnotationGenerator/SerializerGroupsAnnotationGenerator.php
+++ b/src/AnnotationGenerator/SerializerGroupsAnnotationGenerator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the schema-generator.
+ *
+ * (c) Youssef El Montaser <youssef@elmontaser.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ApiPlatform\SchemaGenerator\AnnotationGenerator;
+
+/**
+ * Symfony Serializer Groups annotation generator.
+ *
+ * @author Youssef El Montaser <youssef@elmontaser.com>
+ *
+ * @link https://symfony.com/doc/master/components/serializer.html
+ */
+class SerializerGroupsAnnotationGenerator extends AbstractAnnotationGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateFieldAnnotations($className, $fieldName)
+    {
+        $annotations = [];
+
+        $properties = $this->config['types'][$className]['properties'];
+
+        if ($this->classes[$className]['fields'][$fieldName]['isId'] == false && $groups = $properties[$fieldName]['groups']) {
+            $annotations[] = sprintf('@Groups({"%s"})', implode('","', $groups));
+        }
+
+        return $annotations;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateUses($className)
+    {
+        return ['Symfony\Component\Serializer\Annotation\Groups'];
+    }
+}

--- a/src/AnnotationGenerator/SerializerGroupsAnnotationGenerator.php
+++ b/src/AnnotationGenerator/SerializerGroupsAnnotationGenerator.php
@@ -27,7 +27,7 @@ class SerializerGroupsAnnotationGenerator extends AbstractAnnotationGenerator
 
         $properties = $this->config['types'][$className]['properties'];
 
-        if ($this->classes[$className]['fields'][$fieldName]['isId'] == false && $groups = $properties[$fieldName]['groups']) {
+        if (false === $this->classes[$className]['fields'][$fieldName]['isId'] && $groups = $properties[$fieldName]['groups']) {
             $annotations[] = sprintf('@Groups({"%s"})', implode('","', $groups));
         }
 

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -109,6 +109,10 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                                             CardinalitiesExtractor::CARDINALITY_N_N,
                                             CardinalitiesExtractor::CARDINALITY_UNKNOWN,
                                         ])->end()
+                                        ->arrayNode('groups')
+                                            ->info('Symfony Serialization Groups')
+                                            ->prototype('scalar')->end()
+                                        ->end()
                                     ->end()
                                 ->end()
                             ->end()


### PR DESCRIPTION
Add the generator

```php
annotationGenerators:
    - ....
    - ApiPlatform\SchemaGenerator\AnnotationGenerator\SerializerGroupsAnnotationGenerator
```

Example:
```yml
types:
  Person:
    parent: false
    properties:
      name: { groups : [ public, other ] } 
      familyName: ~
      givenName: ~
      additionalName: ~
      gender: ~
      address: ~
      birthDate: ~
      telephone: ~
      email: ~
      jobTitle: ~
```

```php
<?php

namespace AddressBook\Entity;

use Symfony\Component\Serializer\Annotation\Groups;
...

/**
 * A person (alive, dead, undead, or fictional).
 * 
 * @see http://schema.org/Person Documentation on Schema.org
 * 
 * @ORM\Entity
 * @Iri("http://schema.org/Person")
 */
class Person
{
    /**
     * @var int
     * 
     * @ORM\Column(type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    private $id;
     /**
     * @var string The name of the item.
     * 
     * @ORM\Column(nullable=true)
     * @Assert\Type(type="string")
     * @Iri("https://schema.org/name")
     * @Groups({"public","other"})
     */
    private $name;