### PR TITLE
Add nullable option

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -538,10 +538,15 @@ class TypesGenerator
                 CardinalitiesExtractor::CARDINALITY_1_N,
                 CardinalitiesExtractor::CARDINALITY_N_N,
             ]);
-            $isNullable = !in_array($cardinality, [
-                CardinalitiesExtractor::CARDINALITY_1_1,
-                CardinalitiesExtractor::CARDINALITY_1_N,
-            ]);
+
+            if (false === $typeConfig['properties'][$propertyName]['nullable']) {
+                $isNullable = false;
+            } else {
+                $isNullable = !in_array($cardinality, [
+                    CardinalitiesExtractor::CARDINALITY_1_1,
+                    CardinalitiesExtractor::CARDINALITY_1_N,
+                ]);
+            }
 
             $class['fields'][$propertyName] = [
                 'name' => $propertyName,

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -113,6 +113,7 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                                             ->info('Symfony Serialization Groups')
                                             ->prototype('scalar')->end()
                                         ->end()
+                                        ->scalarNode('nullable')->defaultTrue()->info('The property nullable')->end()
                                     ->end()
                                 ->end()
                             ->end()


### PR DESCRIPTION
By default the nullable option is a true except for cardinality 1-1 and 1-n. 
This change can force this option to  properties, and add the ```@Assert\NotNull``` constraint.

Example:
```yml
types:
  Person:
    parent: false
    properties:
      name: ~
      address: ~
      birthDate: ~
      telephone: ~
      email: { nullable: false }
      jobTitle: ~
```

```php
class Person
{
    /**
     * @var string Email address.
     * 
     * @ORM\Column
     * @Assert\Email
     * @Assert\NotNull
     * @Iri("https://schema.org/email")
     */
    private $email;

...
```