### PR TITLE
Import namespace for the generated class and the property range.

### DIFF
--- a/src/NamespaceGenerator/AbstractNamespaceGenerator.php
+++ b/src/NamespaceGenerator/AbstractNamespaceGenerator.php
@@ -19,7 +19,9 @@ abstract class AbstractNamespaceGenerator implements NamespaceGeneratorInterface
      * @var \EasyRdf_Graph[]
      */
     protected $graphs;
-
+    /**
+     * @var array
+     */
     protected $cardinalities;
     /**
      * @var array

--- a/src/NamespaceGenerator/AbstractNamespaceGenerator.php
+++ b/src/NamespaceGenerator/AbstractNamespaceGenerator.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ApiPlatform\SchemaGenerator\NamespaceGenerator;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Namespace Generator
+ *
+ * @author Sidney Curron <ceednee@gmail.com>
+ */
+abstract class AbstractNamespaceGenerator implements NamespaceGeneratorInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+    /**
+     * @var \EasyRdf_Graph[]
+     */
+    protected $graphs;
+
+    protected $cardinalities;
+    /**
+     * @var array
+     */
+    protected $config;
+    /**
+     * @var array
+     */
+    protected $classes;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        array $graphs,
+        array $cardinalities,
+        array $config,
+        array $classes
+    ) {
+        $this->logger = $logger;
+        $this->graphs = $graphs;
+        $this->cardinalities = $cardinalities;
+        $this->config = $config;
+        $this->classes = $classes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateUses($className)
+    {
+        return [];
+    }
+} 

--- a/src/NamespaceGenerator/NamespaceGenerator.php
+++ b/src/NamespaceGenerator/NamespaceGenerator.php
@@ -35,13 +35,15 @@ class NamespaceGenerator extends AbstractNamespaceGenerator
      */
     public function generateUses($className)
     {
-        echo 'classname => ' . $className . "\n";
-
         $uses = [];
 
-        foreach($this->getClassProperties($className) as $property => $values) {
+        foreach($this->getTypeProperties($className) as $property => $values) {
             if ($values['range']) {
-                $uses[] = $this->getClassNameSpace($values['range']);
+                if ($this->isTypeNamespaceClassDefined($values['range'])) {
+                    $uses[] = $this->getTypeNamespaceClass($values['range']).'\\'.$values['range'];
+                } else {
+                    $uses[] = $this->getGlobalNamespaceClass().'\\'.$values['range'];
+                }
             }
         }
 
@@ -49,22 +51,64 @@ class NamespaceGenerator extends AbstractNamespaceGenerator
     }
 
     /**
-     * @param $className
+     * Returns global PHP namespace of generated entities
      *
-     * @return mixed
+     * @return null
      */
-    private function getClassNameSpace($className)
+    private function getGlobalNamespaceClass()
     {
-        return $this->config['types'][$className]['namespaces']['class'].'\\'.$className;;
+        if (isset($this->config['namespaces']['entity'])) {
+            return $this->config['namespaces']['entity'];
+        }
+
+        return null;
     }
 
     /**
-     * @param $className
+     * Whether or not a namespace's class is defined for the current type
+     *
+     * @param string $type
+     *
+     * @return bool
+     */
+    private function isTypeNamespaceClassDefined($type)
+    {
+        if (isset($this->config['types'][$type]['namespaces']['class'])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the defined namespace of the current type
+     *
+     * @param string $type
      *
      * @return mixed
      */
-    private function getClassProperties($className)
+    private function getTypeNamespaceClass($type)
     {
-        return $this->config['types'][$className]['properties'];
+        if ($this->isTypeNamespaceClassDefined($type)) {
+            return $this->config['types'][$type]['namespaces']['class'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the properties of the current type
+     *
+     * @param string $type
+     *
+     * @return array
+     */
+    private function getTypeProperties($type)
+    {
+        if (isset($this->config['types'][$type]['properties'])) {
+            return $this->config['types'][$type]['properties'];
+        }
+
+        return [];
     }
 }

--- a/src/NamespaceGenerator/NamespaceGenerator.php
+++ b/src/NamespaceGenerator/NamespaceGenerator.php
@@ -85,7 +85,7 @@ class NamespaceGenerator extends AbstractNamespaceGenerator
      *
      * @param string $type
      *
-     * @return mixed
+     * @return string|null
      */
     private function getTypeNamespaceClass($type)
     {

--- a/src/NamespaceGenerator/NamespaceGenerator.php
+++ b/src/NamespaceGenerator/NamespaceGenerator.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * (c) Sidney Curron <ceednee@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace ApiPlatform\SchemaGenerator\NamespaceGenerator;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Namespace Generator
+ *
+ * @author Sidney Curron <ceednee@gmail.com>
+ */
+class NamespaceGenerator extends AbstractNamespaceGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        array $graphs,
+        array $cardinalities,
+        array $config,
+        array $classes
+    ) {
+        parent::__construct($logger, $graphs, $cardinalities, $config, $classes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateUses($className)
+    {
+        echo 'classname => ' . $className . "\n";
+
+        $uses = [];
+
+        foreach($this->getClassProperties($className) as $property => $values) {
+            if ($values['range']) {
+                $uses[] = $this->getClassNameSpace($values['range']);
+            }
+        }
+
+        return $uses;
+    }
+
+    /**
+     * @param $className
+     *
+     * @return mixed
+     */
+    private function getClassNameSpace($className)
+    {
+        return $this->config['types'][$className]['namespaces']['class'].'\\'.$className;;
+    }
+
+    /**
+     * @param $className
+     *
+     * @return mixed
+     */
+    private function getClassProperties($className)
+    {
+        return $this->config['types'][$className]['properties'];
+    }
+}

--- a/src/NamespaceGenerator/NamespaceGeneratorInterface.php
+++ b/src/NamespaceGenerator/NamespaceGeneratorInterface.php
@@ -21,8 +21,8 @@ interface NamespaceGeneratorInterface
     /**
      * @param LoggerInterface $logger
      * @param array           $graphs
-     * @param array            $config
-     * @param array            $classes
+     * @param array           $config
+     * @param array           $classes
      */
     public function __construct(
         LoggerInterface $logger,

--- a/src/NamespaceGenerator/NamespaceGeneratorInterface.php
+++ b/src/NamespaceGenerator/NamespaceGeneratorInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * (c) Sidney Curron <ceednee@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace ApiPlatform\SchemaGenerator\NamespaceGenerator;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Namespace Generator Interface
+ *
+ * @author Sidney Curron <ceednee@gmail.com>
+ */
+interface NamespaceGeneratorInterface
+{
+    /**
+     * @param LoggerInterface $logger
+     * @param array           $graphs
+     * @param array            $config
+     * @param array            $classes
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        array $graphs,
+        array $cardinalities,
+        array $config,
+        array $classes
+    );
+
+    /**
+     * Generates uses.
+     *
+     * @param string $className
+     *
+     * @return array
+     */
+    public function generateUses($className);
+}

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -36,6 +36,14 @@ class TypesGenerator
     const DOCTRINE_COLLECTION_USE = 'Doctrine\Common\Collections\ArrayCollection';
     /**
      * @var string
+     */
+    const FOS_USER_BUNDLE_USE = 'FOS\UserBundle\Model\User as BaseUser';
+    /**
+     * @var string
+     */
+    const FOS_USER_BUNDLE_CLASS_ALIAS = 'BaseUser';
+    /**
+     * @var string
      *
      * @see https://github.com/myclabs/php-enum Used enum implementation
      */
@@ -241,6 +249,15 @@ class TypesGenerator
                 $class['abstract'] = $config['types'][$class['name']]['abstract'];
             } else {
                 $class['abstract'] = $class['hasChild'];
+            }
+
+            if (isset($config['types'][$class['name']]['extendFOSUser']) &&
+                null !== $config['types'][$class['name']]['extendFOSUser'] &&
+                false === $class['parent']
+            ) {
+                $class['extendFOSUser'] = $config['types'][$class['name']]['extendFOSUser'];
+                $class['parent'] = self::FOS_USER_BUNDLE_CLASS_ALIAS;
+                $class['uses'][] = self::FOS_USER_BUNDLE_USE;
             }
         }
 

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -35,15 +35,7 @@ class TypesGenerator
      * @see https://github.com/doctrine/collections
      */
     const DOCTRINE_COLLECTION_USE = 'Doctrine\Common\Collections\ArrayCollection';
-    /**
-     * @var string
-     */
-    const FOS_USER_BUNDLE_USE = 'FOS\UserBundle\Model\User as BaseUser';
-    /**
-     * @var string
-     */
-    const FOS_USER_BUNDLE_CLASS_ALIAS = 'BaseUser';
-    /**
+   /**
      * @var string
      *
      * @see https://github.com/myclabs/php-enum Used enum implementation
@@ -250,16 +242,6 @@ class TypesGenerator
                 $class['abstract'] = $config['types'][$class['name']]['abstract'];
             } else {
                 $class['abstract'] = $class['hasChild'];
-            }
-
-            // class will extends FosUserBundle
-            if (isset($config['types'][$class['name']]['extendFOSUser']) &&
-                null !== $config['types'][$class['name']]['extendFOSUser'] &&
-                false === $class['parent']
-            ) {
-                $class['extendFOSUser'] = $config['types'][$class['name']]['extendFOSUser'];
-                $class['parent'] = self::FOS_USER_BUNDLE_CLASS_ALIAS;
-                $class['uses'][] = self::FOS_USER_BUNDLE_USE;
             }
         }
 

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -76,7 +76,6 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('vocabularyNamespace')->defaultValue(TypesGenerator::SCHEMA_ORG_NAMESPACE)->info('Namespace of the vocabulary the type belongs to.')->end()
                             ->booleanNode('abstract')->defaultNull()->info('Is the class abstract? (null to guess)')->end()
-                            ->booleanNode('extendFOSUser')->defaultNull()->info('Is the class should extends FOSUser Bundle?')->end()
                             ->arrayNode('namespaces')
                                 ->addDefaultsIfNotSet()
                                 ->info('Type namespaces')
@@ -128,6 +127,13 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\PhpDocAnnotationGenerator',
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\ConstraintAnnotationGenerator',
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\DoctrineOrmAnnotationGenerator',
+                    ])
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('namespaceGenerators')
+                    ->info('Namespace generators to use')
+                    ->defaultValue([
+                        'ApiPlatform\SchemaGenerator\NamespaceGenerator\NamespaceGenerator',
                     ])
                     ->prototype('scalar')->end()
                 ->end()

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -76,6 +76,7 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('vocabularyNamespace')->defaultValue(TypesGenerator::SCHEMA_ORG_NAMESPACE)->info('Namespace of the vocabulary the type belongs to.')->end()
                             ->booleanNode('abstract')->defaultNull()->info('Is the class abstract? (null to guess)')->end()
+                            ->booleanNode('extendFOSUser')->defaultNull()->info('Is the class should extends FOSUser Bundle?')->end()
                             ->arrayNode('namespaces')
                                 ->addDefaultsIfNotSet()
                                 ->info('Type namespaces')


### PR DESCRIPTION
|Q|A|
---|---
|**WIP**|**yes**|
|Bug fix?|no|
|**New Feature?** |**yes**|
|BC Breaks? |no|
|Deprecations?|no|
|Tests pass?|no|
|Fixed tickets|n/a|
|License|MIT|

schema-generator does not take into account the namespace for the generated class, nor the namespace of the property range, it lacks the use operator (see https://github.com/api-platform/schema-generator/issues/24).

Example, generating schema entity for:

```yml
types:
    PostalAddress:
        parent: false
        namespaces:
            class: AppBundle\Entity\Schema
        properties:
        ...

    Organization:
        parent: false
        abstract: true
        namespaces:
            class: AppBundle\Entity\Schema\Foo\Bar
        properties:
        ...

    Person:
        namespaces:
            class: AppBundle\Entity\Schema\Person
        properties:
             address:
                 range:      PostalAddress
                 cardinality: (*..0)
             worksFor:
                 range:      Organization
                 cardinality: (*..0)
```
Will create the entity class **Person and its setters**:

```php
<?php

namespace AppBundle\Entity\Schema\Person;

use Doctrine\ORM\Mapping as ORM;
use Dunglas\ApiBundle\Annotation\Iri;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * A person (alive, dead, undead, or fictional).
 *
 * @see http://schema.org/Person Documentation on Schema.org
 *
 * @Iri("http://schema.org/Person")
 */
class Person
{
    /**
     * @var int
     *
     * @ORM\Column(type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    protected $id;
    /**
     * @var PostalAddress Physical address of the item.
     *
     * @ORM\ManyToOne(targetEntity="PostalAddress")
     * @Iri("https://schema.org/address")
     */
    protected $address;
    /**
     * @var Organization Organizations that the person works for.
     *
     * @ORM\ManyToOne(targetEntity="Organization")
     * @Iri("https://schema.org/worksFor")
     */
    protected $worksFor;

    /**
     * Gets id.
     *
     * @return int
     */
    public function getId()
    {
        return $this->id;
    }

    /**
     * Sets address.
     *
     * @param PostalAddress $address
     *
     * @return $this
     */
    public function setAddress(PostalAddress $address = null)
    {
        $this->address = $address;

        return $this;
    }

    /**
     * Sets worksFor.
     *
     * @param Organization $worksFor
     *
     * @return $this
     */
    public function setWorksFor(Organization $worksFor = null)
    {
        $this->worksFor = $worksFor;

        return $this;
    }
}
```
No namespaces are imported for the types hinting: PostalAddress and Organization!

Theses namespaces should be imported into the class **Person**:
```php
use AppBundle\Entity\Schema\PostalAddress;
use AppBundle\Entity\Schema\Foo\Bar\Organization;
```


**Usage:**
In schema.yml
```yml
annotationGenerators:
    - ApiPlatform\SchemaGenerator\AnnotationGenerator\PhpDocAnnotationGenerator
    - ...

# add the new namespacesGenerators
namespaceGenerators:
    - ApiPlatform\SchemaGenerator\NamespaceGenerator\NamespaceGenerator
```

This new feature will import all namespaces of the property range.