### PR TITLE
import namespaces for all defined range

### DIFF
--- a/src/NamespaceGenerator/AbstractNamespaceGenerator.php
+++ b/src/NamespaceGenerator/AbstractNamespaceGenerator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace ApiPlatform\SchemaGenerator\NamespaceGenerator;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Namespace Generator
+ *
+ * @author Sidney Curron <ceednee@gmail.com>
+ */
+abstract class AbstractNamespaceGenerator implements NamespaceGeneratorInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+    /**
+     * @var \EasyRdf_Graph[]
+     */
+    protected $graphs;
+
+    /**
+     * @var array
+     */
+    protected $cardinalities;
+    /**
+     * @var array
+     */
+    protected $config;
+    /**
+     * @var array
+     */
+    protected $classes;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        array $graphs,
+        array $cardinalities,
+        array $config,
+        array $classes
+    ) {
+        $this->logger = $logger;
+        $this->graphs = $graphs;
+        $this->cardinalities = $cardinalities;
+        $this->config = $config;
+        $this->classes = $classes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateUses($className)
+    {
+        return [];
+    }
+}
+

--- a/src/NamespaceGenerator/AbstractNamespaceGenerator.php
+++ b/src/NamespaceGenerator/AbstractNamespaceGenerator.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Namespace Generator
  *
- * @author Sidney Curron <ceednee@gmail.com>
+ * @author Sidney Curron <ceednee@restotelry.com>
  */
 abstract class AbstractNamespaceGenerator implements NamespaceGeneratorInterface
 {

--- a/src/NamespaceGenerator/NamespaceGenerator.php
+++ b/src/NamespaceGenerator/NamespaceGenerator.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Namespace Generator
  *
- * @author Sidney Curron <ceednee@gmail.com>
+ * @author Sidney Curron <ceednee@restotelry.com>
  */
 class NamespaceGenerator extends AbstractNamespaceGenerator
 {

--- a/src/NamespaceGenerator/NamespaceGenerator.php
+++ b/src/NamespaceGenerator/NamespaceGenerator.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * (c) Sidney Curron <ceednee@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace ApiPlatform\SchemaGenerator\NamespaceGenerator;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Namespace Generator
+ *
+ * @author Sidney Curron <ceednee@gmail.com>
+ */
+class NamespaceGenerator extends AbstractNamespaceGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        array $graphs,
+        array $cardinalities,
+        array $config,
+        array $classes
+    ) {
+        parent::__construct($logger, $graphs, $cardinalities, $config, $classes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateUses($className)
+    {
+        $uses = [];
+
+        foreach($this->getClassProperties($className) as $property => $values) {
+            if ($values['range']) {
+                $uses[] = $this->getClassNameSpace($values['range']);
+            }
+        }
+
+        return $uses;
+    }
+
+    /**
+     * @param $className
+     *
+     * @return mixed
+     */
+    private function getClassNameSpace($className)
+    {
+        return $this->config['types'][$className]['namespaces']['class'].'\\'.$className;;
+    }
+
+    /**
+     * @param $className
+     *
+     * @return mixed
+     */
+    private function getClassProperties($className)
+    {
+        return $this->config['types'][$className]['properties'];
+    }
+}

--- a/src/NamespaceGenerator/NamespaceGeneratorInterface.php
+++ b/src/NamespaceGenerator/NamespaceGeneratorInterface.php
@@ -14,7 +14,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Namespace Generator Interface
  *
- * @author Sidney Curron <ceednee@gmail.com>
+ * @author Sidney Curron <ceednee@restotelry.com>
  */
 interface NamespaceGeneratorInterface
 {

--- a/src/NamespaceGenerator/NamespaceGeneratorInterface.php
+++ b/src/NamespaceGenerator/NamespaceGeneratorInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * (c) Sidney Curron <ceednee@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace ApiPlatform\SchemaGenerator\NamespaceGenerator;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Namespace Generator Interface
+ *
+ * @author Sidney Curron <ceednee@gmail.com>
+ */
+interface NamespaceGeneratorInterface
+{
+    /**
+     * @param LoggerInterface $logger
+     * @param array           $graphs
+     * @param array           $cardinalities
+     * @param array           $config
+     * @param array           $classes
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        array $graphs,
+        array $cardinalities,
+        array $config,
+        array $classes
+    );
+
+    /**
+     * Generates uses.
+     *
+     * @param string $className
+     *
+     * @return array
+     */
+    public function generateUses($className);
+}

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -74,7 +74,6 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                     ->useAttributeAsKey('id')
                     ->prototype('array')
                         ->children()
-                            ->scalarNode('vocabularyNamespace')->defaultValue(TypesGenerator::SCHEMA_ORG_NAMESPACE)->info('Namespace of the vocabulary the type belongs to.')->end()
                             ->booleanNode('abstract')->defaultNull()->info('Is the class abstract? (null to guess)')->end()
                             ->arrayNode('namespaces')
                                 ->addDefaultsIfNotSet()
@@ -109,12 +108,6 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                                             CardinalitiesExtractor::CARDINALITY_N_N,
                                             CardinalitiesExtractor::CARDINALITY_UNKNOWN,
                                         ])->end()
-                                        ->arrayNode('groups')
-                                            ->info('Symfony Serialization Groups')
-                                            ->prototype('scalar')->end()
-                                        ->end()
-                                        ->scalarNode('nullable')->defaultTrue()->info('The property nullable')->end()
-                                        ->scalarNode('unique')->defaultFalse()->info('The property unique')->end()
                                     ->end()
                                 ->end()
                             ->end()
@@ -127,6 +120,13 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\PhpDocAnnotationGenerator',
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\ConstraintAnnotationGenerator',
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\DoctrineOrmAnnotationGenerator',
+                    ])
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('namespaceGenerators')
+                    ->info('Namespace generators to use')
+                    ->defaultValue([
+                        'ApiPlatform\SchemaGenerator\NamespaceGenerator\NamespaceGenerator',
                     ])
                     ->prototype('scalar')->end()
                 ->end()


### PR DESCRIPTION
|Q|A|
---|---
|Bug fix?|no|
|**New Feature?** |**yes**|
|BC Breaks? |no|
|Deprecations?|no|
|Tests pass?|yes|
|Fixed tickets|n/a|
|License|MIT|

schema-generator does not take into account the namespace for the generated class, nor the namespace of the property range, it lacks the use operator (see https://github.com/api-platform/schema-generator/issues/24).

Example, generating schema entity for:

```yml
types:
    PostalAddress:
        parent: false
        namespaces:
            class: AppBundle\Entity\Schema
        properties:
        ...

    Organization:
        parent: false
        abstract: true
        namespaces:
            class: AppBundle\Entity\Schema\Foo\Bar
        properties:
        ...

    Person:
        namespaces:
            class: AppBundle\Entity\Schema\Person
        properties:
             address:
                 range:      PostalAddress
                 cardinality: (*..0)
             worksFor:
                 range:      Organization
                 cardinality: (*..0)
```
Will create the entity class **Person and its setters**:

```php
<?php

namespace AppBundle\Entity\Schema\Person;

use Doctrine\ORM\Mapping as ORM;
use Dunglas\ApiBundle\Annotation\Iri;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * A person (alive, dead, undead, or fictional).
 *
 * @see http://schema.org/Person Documentation on Schema.org
 *
 * @Iri("http://schema.org/Person")
 */
class Person
{
    /**
     * @var int
     *
     * @ORM\Column(type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    protected $id;
    /**
     * @var PostalAddress Physical address of the item.
     *
     * @ORM\ManyToOne(targetEntity="PostalAddress")
     * @Iri("https://schema.org/address")
     */
    protected $address;
    /**
     * @var Organization Organizations that the person works for.
     *
     * @ORM\ManyToOne(targetEntity="Organization")
     * @Iri("https://schema.org/worksFor")
     */
    protected $worksFor;

    /**
     * Gets id.
     *
     * @return int
     */
    public function getId()
    {
        return $this->id;
    }

    /**
     * Sets address.
     *
     * @param PostalAddress $address
     *
     * @return $this
     */
    public function setAddress(PostalAddress $address = null)
    {
        $this->address = $address;

        return $this;
    }

    /**
     * Sets worksFor.
     *
     * @param Organization $worksFor
     *
     * @return $this
     */
    public function setWorksFor(Organization $worksFor = null)
    {
        $this->worksFor = $worksFor;

        return $this;
    }
}
```
No namespaces are imported for the types hinting: PostalAddress and Organization!

Theses namespaces should be imported into the class **Person**:
```php
use AppBundle\Entity\Schema\PostalAddress;
use AppBundle\Entity\Schema\Foo\Bar\Organization;
```


**Usage:**
In schema.yml
```yml
annotationGenerators:
    - ApiPlatform\SchemaGenerator\AnnotationGenerator\PhpDocAnnotationGenerator
    - ...

# add the new namespacesGenerators
namespaceGenerators:
    - ApiPlatform\SchemaGenerator\NamespaceGenerator\NamespaceGenerator
```

This new feature will import all namespaces of the property range.