### PR TITLE
make sure that the good target-entity namespace is generated

### DIFF
--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -212,6 +212,10 @@ class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
             return $class['interfaceName'];
         }
 
+        if (isset($this->config['namespaces']['entity']) && null !== $this->config['namespaces']['entity']) {
+            return $this->config['namespaces']['entity'] . '\\' . $class['name'];
+        }
+
         return $class['name'];
     }
 }

--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -212,8 +212,12 @@ class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
             return $class['interfaceName'];
         }
 
+        if (isset($this->config['types'][$class['name']]['namespaces']['class']) && null !== $this->config['types'][$class['name']]['namespaces']['class']) {
+            return $this->config['types'][$class['name']]['namespaces']['class'].'\\'.$class['name'];
+        }
+
         if (isset($this->config['namespaces']['entity']) && null !== $this->config['namespaces']['entity']) {
-            return $this->config['namespaces']['entity'] . '\\' . $class['name'];
+            return $this->config['namespaces']['entity'].'\\'.$class['name'];
         }
 
         return $class['name'];


### PR DESCRIPTION
|Q|A|
---|---
|Bug fix?|no|
|**New Feature?** |**yes**|
|BC Breaks? |no|
|Deprecations?|no|
|Tests pass?|yes|
|Fixed tickets|n/a|
|License|MIT|

When I'm declaring differents properties ranges:

```yml
types:
    Person:
    parent: false
    abstract: true
    namespaces:
      class: AppBundle\Entity\Schema
    properties:
        address:
            range:      PostalAddress
            cardinality: (*..0)
        homeLocation:
            range:      Place
            cardinality: (*..0)
        ...
```
The target-entity annotations generated are:

```yml
class Person
{
    /**
     * @var int
     * 
     * @ORM\Column(type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    protected $id;

    /**
     * @var PostalAddress Physical address of the item.
     * 
     * @ORM\ManyToOne(targetEntity="PostalAddress")
     * @Iri("https://schema.org/address")
     */
    protected $address;

    /**
     * @var Place A contact location for a person's residence.
     * 
     * @ORM\ManyToOne(targetEntity="Place")
     * @Iri("https://schema.org/homeLocation")
     */
    protected $homeLocation;

    ....
```

If I extend the class Person, this error is displayed:
```bash
The target-entity AppBundle\Entity\Schema\PostalAddress cannot be found in 'AppBundle\Entity\User#address' in .
```

This feature checks and make sure that the good target-entity namespace is generated