### PR TITLE
Handle several parent types if useInterface configuration is set to true

### DIFF
--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -9,6 +9,7 @@
 
 namespace ApiPlatform\SchemaGenerator;
 
+use SchemaOrgModel\TypesGenerator;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 

--- a/templates/class.php.twig
+++ b/templates/class.php.twig
@@ -50,61 +50,61 @@ use {{ use }};
 {% for field in class.fields %}
 {% if config.doctrine.useCollection and field.isArray and field.typeHint and not field.isEnum %}
         $this->{{ field.name }} = new ArrayCollection();
-{% endif %}
+    {% endif %}
 {% endfor %}
     }
 {% endif %}
 
 {% for field in class.fields %}
-{% if field.isArray %}
-    /**
-{% for annotation in field.adderAnnotations %}
-     * {{ annotation }}
-{% endfor %}
-     */
-    public function add{{ field.name|ucfirst }}({% if field.typeHint and not field.isEnum %}{{ field.typeHint }} {% endif %}${{ field.name }})
-    {
+    {% if field.isArray %}
+        /**
+        {% for annotation in field.adderAnnotations %}
+            * {{ annotation }}
+        {% endfor %}
+        */
+        public function add{{ field.name|ucfirst }}({% if field.typeHint and not field.isEnum %}{{ field.typeHint }} {% endif %}${{ field.name }})
+        {
         $this->{{ field.name }}[] = {% if field.isEnum %}(string) {% endif %}${{ field.name }};
 
         return $this;
-    }
+        }
 
-    /**
-{% for annotation in field.removerAnnotations %}
-     * {{ annotation }}
-{% endfor %}
-     */
-    public function remove{{ field.name|ucfirst }}({% if field.typeHint %}{{ field.typeHint }} {% endif %}${{ field.name }})
-    {
+        /**
+        {% for annotation in field.removerAnnotations %}
+            * {{ annotation }}
+        {% endfor %}
+        */
+        public function remove{{ field.name|ucfirst }}({% if field.typeHint %}{{ field.typeHint }} {% endif %}${{ field.name }})
+        {
         $key = array_search({% if field.isEnum %}(string) {% endif %}${{ field.name }}, $this->{{ field.name }}, true);
         if (false !== $key) {
-            unset($this->{{ field.name }}[$key]);
+        unset($this->{{ field.name }}[$key]);
         }
 
         return $this;
-    }
-{% else %}
-    /**
-{% for annotation in field.setterAnnotations %}
-     * {{ annotation }}
-{% endfor %}
-     */
-    public function set{{ field.name|ucfirst }}({% if field.typeHint %}{{ field.typeHint }} {% endif %}${{ field.name }}{% if field.typeHint and field.isNullable %} = null{% endif %})
-    {
+        }
+    {% else %}
+        /**
+        {% for annotation in field.setterAnnotations %}
+            * {{ annotation }}
+        {% endfor %}
+        */
+        public function set{{ field.name|ucfirst }}({% if field.typeHint %}{{ field.typeHint }} {% endif %}${{ field.name }}{% if field.typeHint and field.isNullable %} = null{% endif %})
+        {
         $this->{{ field.name }} = ${{ field.name }};
 
         return $this;
-    }
-{% endif %}
+        }
+    {% endif %}
 
     /**
-{% for annotation in field.getterAnnotations %}
-     * {{ annotation }}
-{% endfor %}
-     */
+    {% for annotation in field.getterAnnotations %}
+        * {{ annotation }}
+    {% endfor %}
+    */
     public function get{{ field.name|ucfirst }}()
     {
-        return $this->{{ field.name }};
+    return $this->{{ field.name }};
     }
 
 {% endfor %}

--- a/templates/doctrine.xml.twig
+++ b/templates/doctrine.xml.twig
@@ -5,9 +5,9 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
     <doctrine:config>
         <doctrine:orm>
-{% for interface, class in mappings %}
-            <doctrine:resolve-target-entity interface="{{ interface }}">{{ class }}</doctrine:resolve-target-entity>
-{% endfor %}
+            {% for interface, class in mappings %}
+                <doctrine:resolve-target-entity interface="{{ interface }}">{{ class }}</doctrine:resolve-target-entity>
+            {% endfor %}
         </doctrine:orm>
     </doctrine:config>
 </container>

--- a/templates/interface.php.twig
+++ b/templates/interface.php.twig
@@ -15,6 +15,41 @@ namespace {{ class.interfaceNamespace }};
  * {{ annotation }}
 {% endfor %}
  */
-interface {{ class.interfaceName }}
+interface {{ class.interfaceName }}{% if class.parentsInterfaceNames is not empty %} extends {% for interfaceName in class.parentsInterfaceNames %}{{ interfaceName }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}
+
 {
+{% for field in class.fields %}
+{% if field.classOnly == false and (field.name != 'id' or class.parentsInterfaceNames is empty) %}
+{% if field.isArray %}
+    /**
+{% for annotation in field.adderAnnotations %}
+     * {{ annotation }}
+{% endfor %}
+     */
+    public function add{{ field.name|ucfirst }}({% if field.typeHint and not field.isEnum %}{{ field.typeHint }} {% endif %}${{ field.name }});
+
+    /**
+    {% for annotation in field.removerAnnotations %}
+        * {{ annotation }}
+    {% endfor %}
+    */
+    public function remove{{ field.name|ucfirst }}({% if field.typeHint %}{{ field.typeHint }} {% endif %}${{ field.name }});
+{% else %}
+
+    /**
+    {% for annotation in field.setterAnnotations %}
+        * {{ annotation }}
+    {% endfor %}
+    */
+    public function set{{ field.name|ucfirst }}({% if field.typeHint %}{{ field.typeHint }} {% endif %}${{ field.name }}{% if field.typeHint and field.isNullable %} = null{% endif %});
+{% endif %}
+
+    /**
+    {% for annotation in field.getterAnnotations %}
+        * {{ annotation }}
+    {% endfor %}
+    */
+    public function get{{ field.name|ucfirst }}();
+{% endif %}
+{% endfor %}
 }


### PR DESCRIPTION
Types can now implement fields of several parents (and their parents) by using interfaces.
If you don't to want implement a parent field, set the abstract configuration of this type to true and the generator will generate the interface only.

Exemple of generated interface for VideoGame

``` php
/**
 * A video game is an electronic game that involves human interaction with a user interface to generate visual feedback on a video device.
 * 
 * @see http://schema.org/VideoGame Documentation on Schema.org
 */
interface VideoGameInterface extends SoftwareApplicationInterface, GameInterface
{
    /**
     * Sets gamePlatform.
     * 
     * @param string $gamePlatform
     * 
     * @return $this
     */
    public function setGamePlatform($gamePlatform);

    /**
     * Gets gamePlatform.
     * 
     * @return string
     */
    public function getGamePlatform();
}
```