### PR TITLE
Inserts parent class namespace when generating a class hierarchy

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -190,6 +190,10 @@ class TypesGenerator
                     $class['parent'] = $numberOfSupertypes ? $type->all('rdfs:subClassOf')[0]->localName() : false;
                 }
 
+                if (null !== $class['parent']) {
+                    $class['uses'][] =  sprintf('%s\\%s', $config['types']['Thing']['namespaces']['class'], $class['parent']);
+                }
+
                 // Embeddable
                 $class['embeddable'] = isset($typeConfig['embeddable']) ? $typeConfig['embeddable'] : false;
 


### PR DESCRIPTION
|Q|A|
---|---
|**Bug fix?**|**yes**|
|New Feature?|no|
|BC Breaks? |no|
|Deprecations?|no|
|Tests pass?|yes|
|Fixed tickets|https://github.com/api-platform/schema-generator/issues/24 https://github.com/api-platform/schema-generator/pull/30|
|License|MIT|
|Doc PR|n/a|

schema-generator does not take into account the parent class namespace when a class hierarchy is defined.

Example, generating schema entity for:

```yml
types:
    # Parent class of Person
  Thing:
    namespaces:
      class: AppBundle\Entity\Schema\Got\Bar\Thing
    properties:
      name: ~

  Person:
    properties:
      familyName: ~
      givenName: ~
      additionalName: ~
      gender: ~
      birthDate: ~
      telephone: ~
      email: ~
      url: ~
      jobTitle: ~
```
Will create the entity class **Person and its setters**:

```php
<?php

namespace A\Custom\Path\Person;

use Doctrine\ORM\Mapping as ORM;
use Dunglas\ApiBundle\Annotation\Iri;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * A person (alive, dead, undead, or fictional).
 *
 * @see http://schema.org/Person Documentation on Schema.org
 *
 * @Iri("http://schema.org/Person")
 */
class Person extends Thing
{
    /**
     * @var int
     *
     * @ORM\Column(type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    /**
     * @var int
     * 
     * @ORM\Column(type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    private $id;
    /**
     * @var string An additional name for a Person, can be used for a middle name.
     * 
     * @ORM\Column(nullable=true)
     * @Assert\Type(type="string")
     * @Iri("https://schema.org/additionalName")
     */
    private $additionalName;
    /**
     * @var \DateTime Date of birth.
     * 
     * @ORM\Column(type="date", nullable=true)
     * @Assert\Date
     * @Iri("https://schema.org/birthDate")
     */
    private $birthDate;

    ...
}
```

Class **Person** extends class **Thing** but no namespace for **Thing** is imported into the class **Person**:

```php
use AppBundle\Entity\Schema\Got\Bar\Thing\Thing;
```
