### PR TITLE
Added ability to create custom classes

### DIFF
--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -92,6 +92,7 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->scalarNode('parent')->defaultNull()->info('The parent class, set to false for a top level class')->end()
+                            ->scalarNode('guessFrom')->defaultValue('Thing')->info('If declaring a custom class, this will be the class from which properties type will be guessed')->end()
                             ->arrayNode('properties')
                                 ->info('Properties of this type to use')
                                 ->useAttributeAsKey('id')

--- a/templates/interface.php.twig
+++ b/templates/interface.php.twig
@@ -10,11 +10,13 @@
 
 namespace {{ class.interfaceNamespace }};
 
+{% if class.interfaceAnnotations|length > 0 %}
 /**
 {% for annotation in class.interfaceAnnotations %}
  * {{ annotation }}
 {% endfor %}
  */
+{% endif %}
 interface {{ class.interfaceName }}
 {
 }

--- a/tests/config/ecommerce.yml
+++ b/tests/config/ecommerce.yml
@@ -45,10 +45,17 @@ types:
       height: { range: "Text" }
       weight: { range: "Text" }
       width: { range: "Text" }
+      seller: { range: "Seller" }
   Brand:
     parent: "Thing"
     properties:
       logo: { range: "ImageObject" }
+  Seller:
+    parent: false
+    guessFrom: Person
+    properties:
+      name: ~
+      birthDate: ~
   ImageObject:
     parent: Thing
     properties:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR allows to create custom classes.
If the class is not found on rdf provided, it will create the class anyway. The class will be supporting base types from the `guessFrom` parameter (`Thing` if none is given).

I did this because I'm currently creating a new schema, and this allows to generate custom entities and relations, making this tool more awesome :)

BTW, didn't find anymore the doc in the repo, I don't know where I should complete it.

Hope I'll succeed to keep this PR clean this time!