### PR TITLE
Add ability to specify the format of the RDFa URI in the configuration

### DIFF
--- a/src/Command/GenerateTypesCommand.php
+++ b/src/Command/GenerateTypesCommand.php
@@ -66,10 +66,10 @@ class GenerateTypesCommand extends Command
         $graphs = [];
         foreach ($processedConfiguration['rdfa'] as $rdfa) {
             $graph = new \EasyRdf_Graph();
-            if ('http://' === substr($rdfa, 0, 7) || 'https://' === substr($rdfa, 0, 8)) {
-                $graph->load($rdfa);
+            if ('http://' === substr($rdfa['uri'], 0, 7) || 'https://' === substr($rdfa['uri'], 0, 8)) {
+                $graph->load($rdfa['uri'], $rdfa['format']);
             } else {
-                $graph->parseFile($rdfa);
+                $graph->parseFile($rdfa['uri'], $rdfa['format']);
             }
 
             $graphs[] = $graph;

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -32,11 +32,16 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('rdfa')
-                    ->info('RDFa files to use')
+                    ->info('RDFa files')
                     ->defaultValue([
-                        self::SCHEMA_ORG_RDFA_URL,
+                        ['uri' => self::SCHEMA_ORG_RDFA_URL, 'format' => null],
                     ])
-                    ->prototype('scalar')->end()
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('uri')->defaultValue(self::SCHEMA_ORG_RDFA_URL)->info('RDFa URI to use')->example(self::SCHEMA_ORG_RDFA_URL)->end()
+                            ->scalarNode('format')->defaultNull()->info('RDFa URI data format')->example('rdfxml')->end()
+                        ->end()
+                    ->end()
                 ->end()
                 ->arrayNode('relations')
                     ->info('OWL relation files to use')

--- a/tests/config/ecommerce.yml
+++ b/tests/config/ecommerce.yml
@@ -8,7 +8,9 @@ header: |
    * file that was distributed with this source code.
    */
 rdfa:
-  - tests/data/schema.rdfa
+  -
+    uri:    tests/data/schema.rdfa
+    format: rdfa
 relations:
   - tests/data/v1.owl
 namespaces:

--- a/tests/config/vgo.yml
+++ b/tests/config/vgo.yml
@@ -12,5 +12,8 @@ types:
   Thing: ~
 debug: true
 rdfa:
-  - tests/data/vgo.rdf
-  - tests/data/schema.rdfa
+  -
+    uri:    tests/data/vgo.rdf
+    format: ~
+  -
+    uri:    tests/data/schema.rdfa


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | api-platform/doc#36

This PR add ability to specify the format of the RDFa URI in the configuration.
In fact if I use a URI like `https://raw.githubusercontent.com/schemaorg/schemaorg/sdo-gozer/data/schema.rdfa` ([api-platform/api-platform/blob/master/app/config/schema.yml#L6](https://github.com/api-platform/api-platform/blob/master/app/config/schema.yml#L6)), the guessed type is `text/plain` instead of `rdfa` or `text/html` and an exception is thrown:
```
  [EasyRdf_Parser_Exception]           
  Failed to parse statement on line 1  
```
So, I resolved this exception by modifying the configuration like this:
```yaml
rdfa:
  -
    uri: https://raw.githubusercontent.com/schemaorg/schemaorg/sdo-gozer/data/schema.rdfa
    format: rdfa

# ...
```