### PR TITLE
Minor tweaks and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.2.0
+
+* The default config now match the Symfony's and API Platform's Best Practices (namespaces)
+* The API Platform's annotation generator is enabled by default
+* Use HTTPS to retrieve vocabularies by default
+* Properties are generated in the order of the config file
+* Properties and constants are separated by an empty line
+
 ## 1.1.2
 
 * Fix a bug when generating enumerations

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -21,8 +21,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class TypesGeneratorConfiguration implements ConfigurationInterface
 {
-    const SCHEMA_ORG_RDFA_URL = 'http://schema.org/docs/schema_org_rdfa.html';
-    const GOOD_RELATIONS_OWL_URL = 'http://purl.org/goodrelations/v1.owl';
+    const SCHEMA_ORG_RDFA_URL = 'https://schema.org/docs/schema_org_rdfa.html';
+    const GOOD_RELATIONS_OWL_URL = 'https://purl.org/goodrelations/v1.owl';
 
     /**
      * {@inheritdoc}
@@ -70,9 +70,9 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->info('PHP namespaces')
                     ->children()
-                        ->scalarNode('entity')->defaultValue('SchemaOrg\Entity')->info('The namespace of the generated entities')->example('Acme\Entity')->end()
-                        ->scalarNode('enum')->defaultValue('SchemaOrg\Enum')->info('The namespace of the generated enumerations')->example('Acme\Enum')->end()
-                        ->scalarNode('interface')->defaultValue('SchemaOrg\Model')->info('The namespace of the generated interfaces')->example('Acme\Model')->end()
+                        ->scalarNode('entity')->defaultValue('AppBundle\Entity')->info('The namespace of the generated entities')->example('Acme\Entity')->end()
+                        ->scalarNode('enum')->defaultValue('AppBundle\Enum')->info('The namespace of the generated enumerations')->example('Acme\Enum')->end()
+                        ->scalarNode('interface')->defaultValue('AppBundle\Model')->info('The namespace of the generated interfaces')->example('Acme\Model')->end()
                     ->end()
                 ->end()
                 ->arrayNode('doctrine')
@@ -161,6 +161,7 @@ class TypesGeneratorConfiguration implements ConfigurationInterface
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\PhpDocAnnotationGenerator',
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\ConstraintAnnotationGenerator',
                         'ApiPlatform\SchemaGenerator\AnnotationGenerator\DoctrineOrmAnnotationGenerator',
+                        'ApiPlatform\SchemaGenerator\AnnotationGenerator\ApiPlatformCoreAnnotationGenerator',
                     ])
                     ->prototype('scalar')->end()
                 ->end()

--- a/templates/class.php.twig
+++ b/templates/class.php.twig
@@ -29,6 +29,7 @@ use {{ use }};
 {% endfor %}
      */
     const {{ constant.name }} = '{{ constant.value }}';
+
 {% endfor %}
 
 {% for field in class.fields %}
@@ -38,6 +39,7 @@ use {{ use }};
 {% endfor %}
      */
     {{ config.fieldVisibility }} ${{ field.name }}{% if field.isArray and (field.isEnum or not field.typeHint or not config.doctrine.useCollection) %} = []{% endif %};
+
 {% endfor %}
 
 {% if config.doctrine.useCollection and class.hasConstructor %}

--- a/tests/Command/DumpConfigurationTest.php
+++ b/tests/Command/DumpConfigurationTest.php
@@ -30,7 +30,7 @@ config:
     rdfa:
 
         # RDFa URI to use
-        uri:                  'http://schema.org/docs/schema_org_rdfa.html' # Example: http://schema.org/docs/schema_org_rdfa.html
+        uri:                  'https://schema.org/docs/schema_org_rdfa.html' # Example: https://schema.org/docs/schema_org_rdfa.html
 
         # RDFa URI data format
         format:               null # Example: rdfxml
@@ -39,7 +39,7 @@ config:
     relations:
 
         # Default:
-        - http://purl.org/goodrelations/v1.owl
+        - https://purl.org/goodrelations/v1.owl
 
     # Debug mode
     debug:                false
@@ -60,13 +60,13 @@ config:
     namespaces:
 
         # The namespace of the generated entities
-        entity:               SchemaOrg\Entity # Example: Acme\Entity
+        entity:               AppBundle\Entity # Example: Acme\Entity
 
         # The namespace of the generated enumerations
-        enum:                 SchemaOrg\Enum # Example: Acme\Enum
+        enum:                 AppBundle\Enum # Example: Acme\Enum
 
         # The namespace of the generated interfaces
-        interface:            SchemaOrg\Model # Example: Acme\Model
+        interface:            AppBundle\Model # Example: Acme\Model
 
     # Doctrine
     doctrine:
@@ -158,6 +158,7 @@ config:
         - ApiPlatform\SchemaGenerator\AnnotationGenerator\PhpDocAnnotationGenerator
         - ApiPlatform\SchemaGenerator\AnnotationGenerator\ConstraintAnnotationGenerator
         - ApiPlatform\SchemaGenerator\AnnotationGenerator\DoctrineOrmAnnotationGenerator
+        - ApiPlatform\SchemaGenerator\AnnotationGenerator\ApiPlatformCoreAnnotationGenerator
 
 
 YAML

--- a/tests/config/vgo.yml
+++ b/tests/config/vgo.yml
@@ -1,18 +1,19 @@
-
 annotationGenerators:
     - ApiPlatform\SchemaGenerator\AnnotationGenerator\PhpDocAnnotationGenerator
     - ApiPlatform\SchemaGenerator\AnnotationGenerator\DoctrineOrmAnnotationGenerator
     - ApiPlatform\SchemaGenerator\AnnotationGenerator\ConstraintAnnotationGenerator
     - ApiPlatform\SchemaGenerator\AnnotationGenerator\DunglasApiAnnotationGenerator
+
 namespaces:
   entity: 'AppBundle\Entity'
+
 types:
   Session:
     vocabularyNamespace: http://purl.org/net/VideoGameOntology#
   Thing: ~
+
 debug: true
+
 rdfa:
-  -
-    uri:    tests/data/vgo.rdf
-    format: ~
+  - tests/data/vgo.rdf
   - tests/data/schema.rdfa


### PR DESCRIPTION
* The default config now match the Symfony's and API Platform's Best Practices (namespaces)
* The API Platform's annotation generator is enabled by default
* Use HTTPS to retrieve vocabularies by default
* Properties are generated in the order of the config file
* Properties and constants are separated by an empty line
