### PR TITLE
Add Support for Twig 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/console": "^2.7 || ^3.0",
         "symfony/yaml": "^2.7 || ^3.0",
         "symfony/config": "^2.7 || ^3.0",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.0 || ^2.0",
         "psr/log": "^1.0",
         "easyrdf/easyrdf": "^0.9",
         "league/html-to-markdown": "^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Support Twig 2 in `composer.json`.

Note: Failing tests are not related to this PR, and is currently failing on master