### PR TITLE
[WIP] allow end users use any version of php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
         "twig/twig": "^1.0 || ^2.0",
         "psr/log": "^1.0",
         "easyrdf/easyrdf": "^0.9",
-        "league/html-to-markdown": "^4.0"
+        "league/html-to-markdown": "^4.0",
+        "friendsofphp/php-cs-fixer": "^1.12 || ^2.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
         "symfony/validator": "^2.7",
-        "symfony/filesystem": "^2.7",
-        "friendsofphp/php-cs-fixer": "^1.12"
+        "symfony/filesystem": "^2.7"
     },
     "suggest": {
         "myclabs/php-enum": "For enumerations",

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
         "twig/twig": "^1.0 || ^2.0",
         "psr/log": "^1.0",
         "easyrdf/easyrdf": "^0.9",
-        "league/html-to-markdown": "^4.0",
-        "friendsofphp/php-cs-fixer": "^1.12"
+        "league/html-to-markdown": "^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.2",
         "symfony/validator": "^2.7",
-        "symfony/filesystem": "^2.7"
+        "symfony/filesystem": "^2.7",
+        "friendsofphp/php-cs-fixer": "^1.12"
     },
     "suggest": {
         "myclabs/php-enum": "For enumerations",

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -874,30 +874,34 @@ class TypesGenerator
      */
     private function fixCs(array $files)
     {
-        $config = new Config();
-        $fixer = new Fixer();
-        $fixer->registerBuiltInConfigs();
-        $fixer->registerBuiltInFixers();
+        if (class_exists('\\Symfony\\CS\\Fixer')) {
+            $config = new Config();
+            $fixer = new Fixer();
+            $fixer->registerBuiltInConfigs();
+            $fixer->registerBuiltInFixers();
 
-        $resolver = new ConfigurationResolver();
-        $resolver
-            ->setAllFixers($fixer->getFixers())
-            ->setConfig($config)
-            ->setOptions([
-                'level' => 'symfony',
-                'fixers' => null,
-                'progress' => false,
-            ])
-            ->resolve();
+            $resolver = new ConfigurationResolver();
+            $resolver
+                ->setAllFixers($fixer->getFixers())
+                ->setConfig($config)
+                ->setOptions([
+                    'level' => 'symfony',
+                    'fixers' => null,
+                    'progress' => false,
+                ])
+                ->resolve();
 
-        $config->fixers($resolver->getFixers());
+            $config->fixers($resolver->getFixers());
 
-        $finder = [];
-        foreach ($files as $file) {
-            $finder[] = new \SplFileInfo($file);
+            $finder = [];
+            foreach ($files as $file) {
+                $finder[] = new \SplFileInfo($file);
+            }
+
+            $config->finder(new \ArrayIterator($finder));
+            $fixer->fix($config);
+        } else {
         }
-
-        $config->finder(new \ArrayIterator($finder));
-        $fixer->fix($config);
+        
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #70
| License       | MIT
| Doc PR        | no

I don't see any reason to keep that dependency in "require" section. I am right?
```
$ composer require --dev friendsofphp/php-cs-fixer:^2.0
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - api-platform/schema-generator v1.2.0 requires friendsofphp/php-cs-fixer ^1.12 -> satisfiable by friendsofphp/php-cs-fixer[1.13.x-dev, v1.12.0, v1.12.1, v1.12.2, v1.12.3, v1.12.4, v1.13.0, v1.13.1] but these conflict with your requirements or minimum-stability.
    - api-platform/schema-generator v1.2.0 requires friendsofphp/php-cs-fixer ^1.12 -> satisfiable by friendsofphp/php-cs-fixer[1.13.x-dev, v1.12.0, v1.12.1, v1.12.2, v1.12.3, v1.12.4, v1.13.0, v1.13.1] but these conflict with your requirements or minimum-stability.
    - api-platform/schema-generator v1.2.0 requires friendsofphp/php-cs-fixer ^1.12 -> satisfiable by friendsofphp/php-cs-fixer[1.13.x-dev, v1.12.0, v1.12.1, v1.12.2, v1.12.3, v1.12.4, v1.13.0, v1.13.1] but these conflict with your requirements or minimum-stability.
    - Installation request for api-platform/schema-generator ^1.2 -> satisfiable by api-platform/schema-generator[v1.2.0].
```