### PR TITLE
Isolate the PHAR with PHP-Scoper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ script:
   - |
     if [[ ! $deps && $TRAVIS_PHP_VERSION = "7.1" ]]; then
       composer install --no-dev --prefer-dist --classmap-authoritative --no-progress --no-suggest --ansi;
-      ~/.composer/vendor/bin/php-scoper add-prefix --force;
-      composer -d=build dump-autoload --classmap-authoritative --no-dev;
+      ~/.composer/vendor/bin/php-scoper add-prefix --output-dir=build/schema-generator;
+      composer -d=build/schema-generator dump-autoload --classmap-authoritative --no-dev;
       php -d phar.readonly=0 box.phar build;
       php schema.phar generate-types tmp/ tests/e2e/schema.yml;
       diff tests/e2e/src/AppBundle/Entity/Person.php tmp/AppBundle/Entity/Person.php;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - export PATH="$PATH:$HOME/.composer/vendor/bin"
   - wget https://phar.phpunit.de/phpunit-6.3.phar
+  - composer global require humbug/php-scoper:^1.0@dev
   - if [[ $coverage = 1 ]]; then mkdir -p build/logs; fi
   - if [[ $coverage = 1 ]]; then wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar; fi
   - if [[ $lint = 1 ]]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.4.0/php-cs-fixer.phar; fi
@@ -36,6 +37,8 @@ script:
   - |
     if [[ ! $deps && $TRAVIS_PHP_VERSION = "7.1" ]]; then
       composer install --no-dev --prefer-dist --classmap-authoritative --no-progress --no-suggest --ansi;
+      ~/.composer/vendor/bin/php-scoper add-prefix --force;
+      composer -d=build dump-autoload --classmap-authoritative --no-dev;
       php -d phar.readonly=0 box.phar build;
       php schema.phar generate-types tmp/ tests/e2e/schema.yml;
       diff tests/e2e/src/AppBundle/Entity/Person.php tmp/AppBundle/Entity/Person.php;

--- a/box.json
+++ b/box.json
@@ -1,4 +1,5 @@
 {
+  "base-path": "build",
   "directories": [
     "data/",
     "src/",

--- a/box.json
+++ b/box.json
@@ -1,5 +1,5 @@
 {
-  "base-path": "build",
+  "base-path": "build/schema-generator",
   "directories": [
     "data/",
     "src/",

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -3,10 +3,9 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the humbug/php-scoper package.
+ * This file is part of the API Platform project.
  *
- * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
- *                    Pádraic Brady <padraic.brady@gmail.com>
+ * (c) Kévin Dunglas <dunglas@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,8 +18,7 @@ return [
         Finder::create()->files()
             ->in('src')
             ->in('data')
-            ->in('templates')
-        ,
+            ->in('templates'),
         Finder::create()
             ->files()
             ->ignoreVCS(true)

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the API Platform project.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the humbug/php-scoper package.
+ *
+ * Copyright (c) 2017 Théo FIDRY <theo.fidry@gmail.com>,
+ *                    Pádraic Brady <padraic.brady@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    'finders' => [
+        Finder::create()->files()
+            ->in('src')
+            ->in('data')
+            ->in('templates')
+        ,
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName('/LICENSE|.*\\.md|.*\\.dist|Makefile|composer\\.json|composer\\.lock/')
+            ->exclude([
+                'doc',
+                'test',
+                'test_old',
+                'tests',
+                'Test',
+                'Tests',
+            ])
+            ->in('vendor'),
+        Finder::create()->append([
+            'bin/schema',
+            'composer.json',
+        ]),
+        Finder::create()->append([
+            'vendor/friendsofphp/php-cs-fixer/tests/Test',
+        ]),
+    ],
+    'whitelist' => [
+        'ApiPlatform\Core\Annotation\ApiProperty',
+        'ApiPlatform\Core\Annotation\ApiResource',
+    ],
+    'patchers' => [
+        function (string $filePath, string $prefix, string $content): string {
+            //
+            // PHP-CS-Fixer patch
+            //
+
+            if ($filePath === __DIR__.'/vendor/friendsofphp/php-cs-fixer/src/FixerFactory.php') {
+                return preg_replace(
+                    '/\$fixerClass = \'PhpCsFixer(.*?\;)/',
+                    sprintf('$fixerClass = \'%s\\PhpCsFixer$1', $prefix),
+                    $content
+                );
+            }
+
+            return $content;
+        },
+    ],
+];


### PR DESCRIPTION
- Installed PHP-Scoper as a global dependency (there is no auto-phar on release neither installers yet)
- Modified the PHAR build script to:
  - reduce the number of files to scope (e.g. avoid to scope files from dev deps) & ship (e.g. dev deps)
  - scope the content before building the PHAR
  - optimize the autoloader before building the PHAR
- Added an end to end test for the isolated PHAR: a simple `schema.yml` is provided with the expected files
- Commited the `composer.lock`: if used as a library this does not matter and the tests don't rely on it (a `composer update is ran`). However for shipping the PHAR, specific versions are expected. This is also required by PHP-Scoper as some patches are required and they are by nature extremely brittle. A way to avoid that would be to patch PHP-CS-Fixer directly but that's another story.

Right now the build is failing due to an error in the PHAR. However as it works with the isolated deps (e.g. if I take `build/bin/schema` instead of `schema.phar`) it works so it seems that the error is not coming from those changes.