### PR TITLE
Add public to const

### DIFF
--- a/templates/class.php.twig
+++ b/templates/class.php.twig
@@ -30,7 +30,7 @@ use {{ use }};
      * {{ annotation }}
 {% endfor %}
      */
-    const {{ constant.name }} = '{{ constant.value }}';
+    public const {{ constant.name }} = '{{ constant.value }}';
 
 {% endfor %}
 

--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -345,4 +345,27 @@ PHP
             chdir($currentDir);
         }
     }
+
+    public function testGeneratedEnum()
+    {
+        $outputDir = __DIR__.'/../../build/enum';
+        $config = __DIR__.'/../config/enum.yaml';
+
+        $this->fs->mkdir($outputDir);
+
+        $commandTester = new CommandTester(new GenerateTypesCommand());
+        $this->assertEquals(0, $commandTester->execute(['output' => $outputDir, 'config' => $config]));
+
+        $gender = file_get_contents("$outputDir/AppBundle/Enum/GenderType.php");
+
+        $this->assertContains(<<<'PHP'
+    /**
+     * @var string the female gender
+     */
+    public const FEMALE = 'http://schema.org/Female';
+PHP
+            , $gender);
+
+        $this->assertNotContains('function setId(', $gender);
+    }
 }

--- a/tests/config/enum.yaml
+++ b/tests/config/enum.yaml
@@ -1,0 +1,9 @@
+fieldVisibility: public
+accessorMethods: false
+types:
+  Person:
+    properties:
+      gender: { range: GenderType }
+  GenderType:
+    parent: false
+    guessFrom: GenderType


### PR DESCRIPTION
Because from 7.1 you can define the visibility I think we should specify that is public (even if is the default behaviour).
link: https://wiki.php.net/rfc/class_const_visibility