### PR TITLE
fix #126 - generate unique=true with nullable false properly

### DIFF
--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -129,7 +129,7 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
                     $annotation .= 'nullable=true';
                 }
 
-                if ($field['isUnique'] && $field['isNullable']) {
+                if (($field['isUnique'] && $field['isNullable']) || ($field['isUnique'] && !$field['isNullable'])) {
                     $annotation .= ', ';
                 }
 

--- a/tests/e2e/schema.yml
+++ b/tests/e2e/schema.yml
@@ -15,9 +15,10 @@ types:
             address: ~
             birthDate: ~
             telephone: ~
-            email: ~
             url: ~
             jobTitle: ~
+            email: { unique: true, nullable: false }
+            identifier: { range: "Text", unique: true, nullable: false }
     PostalAddress:
         # Disable the generation of the class hierarchy for this type
         parent: false

--- a/tests/e2e/src/AppBundle/Entity/Person.php
+++ b/tests/e2e/src/AppBundle/Entity/Person.php
@@ -86,13 +86,23 @@ class Person
     private $telephone;
 
     /**
-     * @var string|null email address
+     * @var string email address
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text", unique=true)
      * @ApiProperty(iri="http://schema.org/email")
      * @Assert\Email
+     * @Assert\NotNull
      */
     private $email;
+
+    /**
+     * @var string The identifier property represents any kind of identifier for any kind of \[\[Thing\]\], such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See \[background notes\](/docs/datamodel.html#identifierBg) for more details.
+     *
+     * @ORM\Column(type="text", unique=true)
+     * @ApiProperty(iri="http://schema.org/identifier")
+     * @Assert\NotNull
+     */
+    private $identifier;
 
     /**
      * @var string|null URL of the item
@@ -194,6 +204,16 @@ class Person
     public function getEmail(): ?string
     {
         return $this->email;
+    }
+
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
     }
 
     public function setUrl(?string $url): void


### PR DESCRIPTION
As specified in #126 the php class generated is wrong and cannot be used, this fixes it and add e2e testes to be sure that this won't happen anymore.