### PR TITLE
Allow to embded classes not defined in the current schema.yaml file

### DIFF
--- a/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
+++ b/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
@@ -32,8 +32,10 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
     public function generateClassAnnotations(string $className): array
     {
         $resource = $this->classes[$className]['resource'];
-
-        return [sprintf('@ApiResource(iri="%s")', $resource->getUri())];
+        $security = $this->classes[$className]['config']['security'];
+        //Security default value is false
+        return ($security) ? [sprintf('@ApiResource(iri="%s", %s)', $resource->getUri(), preg_replace('/\s/', '', $security))]
+            : [sprintf('@ApiResource(iri="%s")', $resource->getUri())];
     }
 
     /**

--- a/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
+++ b/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
@@ -34,7 +34,7 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
         $resource = $this->classes[$className]['resource'];
         $security = $this->classes[$className]['config']['security'];
         //Security default value is false
-        return ($security) ? [sprintf('@ApiResource(iri="%s", %s)', $resource->getUri(), preg_replace('/\s/', '', $security))]
+        return ($security) ? [sprintf('@ApiResource(iri="%s", %s)', $resource->getUri(), preg_replace('/\n/', "\n *\t", "\n".$security))]
             : [sprintf('@ApiResource(iri="%s")', $resource->getUri())];
     }
 

--- a/src/AnnotationGenerator/DoctrineMongoDBAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineMongoDBAnnotationGenerator.php
@@ -127,6 +127,10 @@ final class DoctrineMongoDBAnnotationGenerator extends AbstractAnnotationGenerat
      */
     private function getRelationName(string $range): string
     {
+        if (! in_array($range, $this->classes) ) {
+            return $range;
+        }
+
         $class = $this->classes[$range];
 
         return $class[$range]['interfaceName'] ?? $class['name'];

--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -227,6 +227,10 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
      */
     private function getRelationName(string $range): string
     {
+        if (! in_array($range, $this->classes) ) {
+            return $range;
+        }
+
         $class = $this->classes[$range];
 
         if (isset($class['interfaceName'])) {

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -162,6 +162,7 @@ final class TypesGeneratorConfiguration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('parent')->defaultFalse()->info('The parent class, set to false for a top level class')->end()
                             ->scalarNode('guessFrom')->defaultValue('Thing')->info('If declaring a custom class, this will be the class from which properties type will be guessed')->end()
+                            ->scalarNode('security')->defaultValue(false)->info("Security specifications")->end()
                             ->booleanNode('allProperties')->defaultFalse()->info('Import all existing properties')->end()
                             ->arrayNode('properties')
                                 ->info('Properties of this type to use')


### PR DESCRIPTION
example UserBundle.yaml
```
types:

    User: # Outputs to \AppBundle\Entity\UserBundle\User
          properties:
                articles: {range: \AppBundle\Entity\ArticlesBundle\Articles, cardinality: ... }
```
example ArticleBundle.yaml
```
types:

    Article: # Outputs to \AppBundle\Entity\ArticlesBundle\Articles
          properties:
                owner: {range: \AppBundle\Entity\UserBundle\User, cardinality: ... }
```

I needed this to separate my long Yaml files && allow to include ApiResources not defined via the schema generator.

Maybe it would be best to add a notice that the class name was not found on the current schema file, so the full $range string is used?