### PR TITLE
Allow to embded classes not defined in the current schema.yaml file

### DIFF
--- a/src/AnnotationGenerator/DoctrineMongoDBAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineMongoDBAnnotationGenerator.php
@@ -127,6 +127,10 @@ final class DoctrineMongoDBAnnotationGenerator extends AbstractAnnotationGenerat
      */
     private function getRelationName(string $range): string
     {
+        if (! in_array($range, $this->classes) ) {
+            return $range;
+        }
+
         $class = $this->classes[$range];
 
         return $class[$range]['interfaceName'] ?? $class['name'];

--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -227,6 +227,10 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
      */
     private function getRelationName(string $range): string
     {
+        if (! in_array($range, $this->classes) ) {
+            return $range;
+        }
+
         $class = $this->classes[$range];
 
         if (isset($class['interfaceName'])) {


### PR DESCRIPTION
example UserBundle.yaml
```
types:

    User: # Outputs to \AppBundle\Entity\UserBundle\User
          properties:
                articles: {range: \AppBundle\Entity\ArticlesBundle\Article, cardinality: ... }
```
example ArticleBundle.yaml
```
types:

    Article: # Outputs to \AppBundle\Entity\ArticlesBundle\Article
          properties:
                owner: {range: \AppBundle\Entity\UserBundle\User, cardinality: ... }
```

I needed this to separate my long Yaml files && allow to include ApiResources not defined via the schema generator.

Maybe it would be best to add a notice that the class name was not found on the current schema file, so the full `range` string is used?