### PR TITLE
Use correct URL to docs website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ To have your code integrated in the API Platform project, there is some rules to
 
 If you happen to find a bug, we kindly request you to report it. However, before submitting it, please:
 
-  * Check the [project documentation available online](https://api-platform.com/doc/)
+  * Check the [project documentation available online](https://api-platform.com/docs/)
 
 Then, if it appears that it's a real bug, you may report it using Github by following these 3 points:
 


### PR DESCRIPTION
I was reading CONTRIBUTING.md and noticed that the link to the docs was not correct. What would be a better first contribution than a fix in the contribution file? :)

The link pointed to https://api-platform.com/doc/ while the docs are hosted at https://api-platform.com/docs/.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A