### PR TITLE
Correct implicit and explicit property inheritance

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -273,7 +273,10 @@ class TypesGenerator
                     $parentClass = $classes[$class['parent']];
 
                     while ($parentClass) {
-                        if (!isset($parentConfig['properties']) || !is_array($parentConfig['properties'])) {
+                        if (!isset($parentConfig['properties']) ||
+                            !is_array($parentConfig['properties']) ||
+                            0 === count($parentConfig['properties'])
+                        ) {
                             // Unset implicit property
                             $parentType = $parentClass['resource'];
                             if (in_array($property, $propertiesMap[$parentType->getUri()], true)) {

--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -132,6 +132,38 @@ PHP
         $this->assertNotContains('function remove', $person);
     }
 
+    public function testImplicitAndExplicitPropertyInheritance()
+    {
+        $outputDir = __DIR__.'/../../build/inherited-properties';
+        $config = __DIR__.'/../config/inherited-properties.yaml';
+
+        $this->fs->mkdir($outputDir);
+
+        $commandTester = new CommandTester(new GenerateTypesCommand());
+        $this->assertEquals(0, $commandTester->execute(['output' => $outputDir, 'config' => $config]));
+
+        $creativeWork = file_get_contents("$outputDir/AppBundle/Entity/CreativeWork.php");
+        $this->assertContains('class CreativeWork extends Thing', $creativeWork);
+        $this->assertContains('private $copyrightYear;', $creativeWork);
+        $this->assertContains('function getCopyrightYear(', $creativeWork);
+        $this->assertContains('function setCopyrightYear(', $creativeWork);
+        $this->assertNotContains('private $name;', $creativeWork);
+        $this->assertNotContains('function getName(', $creativeWork);
+        $this->assertNotContains('function setName(', $creativeWork);
+
+        $webPage = file_get_contents("$outputDir/AppBundle/Entity/WebPage.php");
+        $this->assertContains('class WebPage extends CreativeWork', $webPage);
+        $this->assertContains('private $mainEntity;', $webPage);
+        $this->assertContains('function getMainEntity(', $webPage);
+        $this->assertContains('function setMainEntity(', $webPage);
+        $this->assertNotContains('private $copyrightYear;', $webPage);
+        $this->assertNotContains('function getCopyrightYear(', $webPage);
+        $this->assertNotContains('function setCopyrightYear(', $webPage);
+        $this->assertNotContains('private $name;', $webPage);
+        $this->assertNotContains('function getName(', $webPage);
+        $this->assertNotContains('function setName(', $webPage);
+    }
+
     public function testReadableWritable()
     {
         $outputDir = __DIR__.'/../../build/readable-writable';

--- a/tests/config/inherited-properties.yaml
+++ b/tests/config/inherited-properties.yaml
@@ -1,0 +1,10 @@
+types:
+  CreativeWork:
+    allProperties: true
+    parent: Thing
+    properties:
+      copyrightYear:
+  Thing:
+  WebPage:
+    allProperties: true
+    parent: CreativeWork


### PR DESCRIPTION
_To maintainers @dunglas, @sroze or @theofidry_

Setting up a config where a child class inherits its parent's  properties
through class inheritance did not work.

The logic in TypesGenerator handled implicit inheritance based on
whether the parent's properties key was not set or not an array, but did
not account for empty arrays.

Also added tests for these implicit and explicit cases.


Q | A
-- | --
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets | #150 
License | MIT
Doc PR | N/A