### PR TITLE
Use superseding props over which they supersede

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -52,6 +52,11 @@ class TypesGenerator
     private const SCHEMA_ORG_RANGE = 'schema:rangeIncludes';
 
     /**
+     * @var string
+     */
+    private const SCHEMA_ORG_SUPERSEDED_BY = 'schema:supersededBy';
+
+    /**
      * @var \Twig_Environment
      */
     private $twig;
@@ -232,7 +237,12 @@ class TypesGenerator
             } else {
                 // All properties
                 foreach ($propertiesMap[$type->getUri()] as $property) {
-                    $class = $this->generateField($config, $class, $type, $typeName, $property->localName(), $property);
+                    if ($property->hasProperty(self::SCHEMA_ORG_SUPERSEDED_BY)) {
+                        $supersededBy = $property->get('schema:supersededBy');
+                        $this->logger->warning(sprintf('The property "%s" is superseded by "%s". Using the superseding property.', $property->localName(), $supersededBy->localName()));
+                    } else {
+                        $class = $this->generateField($config, $class, $type, $typeName, $property->localName(), $property);
+                    }
                 }
             }
 

--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -368,4 +368,38 @@ PHP
 
         $this->assertNotContains('function setId(', $gender);
     }
+
+    public function testSupersededProperties()
+    {
+        $outputDir = __DIR__.'/../../build/superseded-properties';
+        $config = __DIR__.'/../config/superseded-properties.yaml';
+
+        $this->fs->mkdir($outputDir);
+
+        $commandTester = new CommandTester(new GenerateTypesCommand());
+        $this->assertEquals(0, $commandTester->execute(['output' => $outputDir, 'config' => $config]));
+
+        $creativeWork = file_get_contents("$outputDir/AppBundle/Entity/CreativeWork.php");
+
+        $this->assertContains(<<<'PHP'
+    /**
+     * @var string|null an award won by or for this item
+     *
+     * @ORM\Column(type="text", nullable=true)
+     * @ApiProperty(iri="http://schema.org/award")
+     */
+    private $award;
+PHP
+            , $creativeWork);
+
+        $this->assertNotContains(<<<'PHP'
+    /**
+     * @var string|null awards won by or for this item
+     *
+     * @ORM\Column(type="text", nullable=true)
+     */
+    protected $award;
+PHP
+            , $creativeWork);
+    }
 }

--- a/tests/config/superseded-properties.yaml
+++ b/tests/config/superseded-properties.yaml
@@ -1,0 +1,3 @@
+types:
+  CreativeWork:
+    allProperties: true


### PR DESCRIPTION
_To maintainers @dunglas, @sroze or @theofidry_

Properties that are superseded or superseded by a property were both all
created, causing duplicate properties in classes.

For example, property `$award` supersedes `$award` in `CreativeWork`
(https://schema.org/award) but both of these properties were generated
in the class:

```
/**
 * @var string|null an award won by or for this item
 *
 * @ORM\Column(type="text", nullable=true)
 * @ApiProperty(iri="http://schema.org/award")
 */
private $award;

/**
 * @var string|null awards won by or for this item
 *
 * @ORM\Column(type="text", nullable=true)
 */
protected $award;
```

This change uses the property which has been declared as superseding.

Q | A
-- | --
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets | #114, #152
License | MIT
Doc PR

