### PR TITLE
use nullable property for customfields

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -633,8 +633,8 @@ class TypesGenerator
                 CardinalitiesExtractor::CARDINALITY_N_N,
             ], true);
 
-            if (isset($propertyConfig['nullable']) && false === $propertyConfig['nullable']) {
-                $isNullable = false;
+            if (isset($propertyConfig['nullable'])) {
+                $isNullable = (bool) $propertyConfig['nullable'];
             } else {
                 $isNullable = !in_array($cardinality, [
                     CardinalitiesExtractor::CARDINALITY_1_1,


### PR DESCRIPTION
Nullable for a custom field is only used when it's nullable: false or if it has some kind of cardinality.
Nullable: true is completely ignored and not correctly generated (by default it adds: @Assert\NotNull)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #133 #107 #134 
| License       | MIT
| Doc PR        | -