### PR TITLE
Add custom twig template dirs

### DIFF
--- a/src/Command/GenerateTypesCommand.php
+++ b/src/Command/GenerateTypesCommand.php
@@ -146,7 +146,10 @@ final class GenerateTypesCommand extends Command
         $goodRelationsBridge = new GoodRelationsBridge($relations);
         $cardinalitiesExtractor = new CardinalitiesExtractor($graphs, $goodRelationsBridge);
 
-        $loader = new \Twig_Loader_Filesystem(__DIR__.'/../../templates/');
+        $templatePaths = $processedConfiguration['generatorTemplates'];
+        $templatePaths[] = __DIR__ . '/../../templates/';
+
+        $loader = new \Twig_Loader_Filesystem($templatePaths);
         $twig = new \Twig_Environment($loader, ['autoescape' => false, 'debug' => $processedConfiguration['debug']]);
         $twig->addFilter(new \Twig_SimpleFilter('ucfirst', 'ucfirst'));
         $twig->addFilter(new \Twig_SimpleFilter('pluralize', [Inflector::class, 'pluralize']));

--- a/src/Command/GenerateTypesCommand.php
+++ b/src/Command/GenerateTypesCommand.php
@@ -147,7 +147,7 @@ final class GenerateTypesCommand extends Command
         $cardinalitiesExtractor = new CardinalitiesExtractor($graphs, $goodRelationsBridge);
 
         $templatePaths = $processedConfiguration['generatorTemplates'];
-        $templatePaths[] = __DIR__ . '/../../templates/';
+        $templatePaths[] = __DIR__.'/../../templates/';
 
         $loader = new \Twig_Loader_Filesystem($templatePaths);
         $twig = new \Twig_Environment($loader, ['autoescape' => false, 'debug' => $processedConfiguration['debug']]);

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -209,6 +209,10 @@ final class TypesGeneratorConfiguration implements ConfigurationInterface
                     ])
                     ->prototype('scalar')->end()
                 ->end()
+                ->arrayNode('generatorTemplates')
+                    ->info('Directories for custom generator twig templates')
+                    ->prototype('scalar')->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/tests/Command/DumpConfigurationTest.php
+++ b/tests/Command/DumpConfigurationTest.php
@@ -199,6 +199,9 @@ config:
         - ApiPlatform\SchemaGenerator\AnnotationGenerator\ConstraintAnnotationGenerator
         - ApiPlatform\SchemaGenerator\AnnotationGenerator\SerializerGroupsAnnotationGenerator
 
+    # Directories for custom generator twig templates
+    generatorTemplates:   []
+
 
 YAML
                 ,


### PR DESCRIPTION
Add custom twig-template directories for overriding the default twig files.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #158 
| License       | MIT
| Doc PR        | -