### PR TITLE
Fix Travis CI build (php7.2 with `coverage=1 lint=1` stage)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 
 install:
   - if [[ $coverage = 1 ]]; then composer require --dev --no-update 'phpunit/php-code-coverage:^5.3'; fi
-  - if [[ ! $deps ]]; then composer update --prefer-dist --no-progress --no-suggest --ansi; fi
+  - if [[ ! $deps ]]; then composer install --prefer-dist --no-progress --no-suggest --ansi; fi
   - if [[ $deps = 'low' ]]; then composer update --prefer-dist --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi; fi
 
 script:

--- a/tests/e2e/src/AppBundle/Entity/Person.php
+++ b/tests/e2e/src/AppBundle/Entity/Person.php
@@ -31,7 +31,7 @@ class Person
     /**
      * @var string|null Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/familyName")
      */
     private $familyName;
@@ -39,7 +39,7 @@ class Person
     /**
      * @var string|null Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/givenName")
      */
     private $givenName;
@@ -47,7 +47,7 @@ class Person
     /**
      * @var string|null an additional name for a Person, can be used for a middle name
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/additionalName")
      */
     private $additionalName;
@@ -55,7 +55,7 @@ class Person
     /**
      * @var string|null Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender.
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/gender")
      */
     private $gender;
@@ -71,7 +71,7 @@ class Person
     /**
      * @var \DateTimeInterface|null date of birth
      *
-     * @ORM\Column(type="date", nullable=true)
+     * @ORM\Column(type="date",nullable=true)
      * @ApiProperty(iri="http://schema.org/birthDate")
      * @Assert\Date
      */
@@ -80,7 +80,7 @@ class Person
     /**
      * @var string|null the telephone number
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/telephone")
      */
     private $telephone;
@@ -88,7 +88,7 @@ class Person
     /**
      * @var string|null email address
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/email")
      * @Assert\Email
      */
@@ -97,7 +97,7 @@ class Person
     /**
      * @var string|null URL of the item
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/url")
      * @Assert\Url
      */
@@ -106,7 +106,7 @@ class Person
     /**
      * @var string|null the job title of the person (for example, Financial Manager)
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/jobTitle")
      */
     private $jobTitle;

--- a/tests/e2e/src/AppBundle/Entity/PostalAddress.php
+++ b/tests/e2e/src/AppBundle/Entity/PostalAddress.php
@@ -30,7 +30,7 @@ class PostalAddress
     /**
      * @var string|null The country. For example, USA. You can also provide the two-letter \[ISO 3166-1 alpha-2 country code\](http://en.wikipedia.org/wiki/ISO\_3166-1).
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/addressCountry")
      */
     private $addressCountry;
@@ -38,7 +38,7 @@ class PostalAddress
     /**
      * @var string|null The locality. For example, Mountain View.
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/addressLocality")
      */
     private $addressLocality;
@@ -46,7 +46,7 @@ class PostalAddress
     /**
      * @var string|null The region. For example, CA.
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/addressRegion")
      */
     private $addressRegion;
@@ -54,7 +54,7 @@ class PostalAddress
     /**
      * @var string|null the post office box number for PO box addresses
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/postOfficeBoxNumber")
      */
     private $postOfficeBoxNumber;
@@ -62,7 +62,7 @@ class PostalAddress
     /**
      * @var string|null The postal code. For example, 94043.
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/postalCode")
      */
     private $postalCode;
@@ -70,7 +70,7 @@ class PostalAddress
     /**
      * @var string|null The street address. For example, 1600 Amphitheatre Pkwy.
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/streetAddress")
      */
     private $streetAddress;

--- a/tests/e2e/src/AppBundle/Entity/Thing.php
+++ b/tests/e2e/src/AppBundle/Entity/Thing.php
@@ -30,7 +30,7 @@ class Thing
     /**
      * @var string|null the name of the item
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/name")
      */
     private $name;


### PR DESCRIPTION
This PR fixes the failing Travis CI build stage. Running builds that have succeeded in the past cause them to fail when ran again. The problem consisted of 2 parts (kept 2 commits because different tickets, but same purpose of fixing build :man_shrugging:).

# Problem 1: A namespacing error (#166)

Example build: https://travis-ci.org/api-platform/schema-generator/jobs/541147735

The dependencies aren't locked down very strict and a composer update was done before this travis stage was ran. This caused the dependencies for this stage to be updated beyond the lock file. Changing the command from update to install solved this.

# Problem 2: Whitespace in e2e test files (#167)

Because of problem 1, the compile script never reached the point where it tests to diff against the produced files in tests/e2e/. Because the tests had been failing for some time, something changed which makes the files not match with the produced files anymore (but it's only a space):

```+ php schema.phar generate-types tmp/ tests/e2e/schema.yml
[warning] The property "address" (type "Person") has several types. Using the first one ("PostalAddress") or possible options("PostalAddress", "Text").
+ diff tests/e2e/src/AppBundle/Entity/Person.php tmp/AppBundle/Entity/Person.php
34c34
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
42c42
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
50c50
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
58c58
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
74c74
<      * @ORM\Column(type="date", nullable=true)
---
>      * @ORM\Column(type="date",nullable=true)
83c83
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
91c91
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
100c100
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
109c109
<      * @ORM\Column(type="text", nullable=true)
---
>      * @ORM\Column(type="text",nullable=true)
```

Q | A
-- | --
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets |  #166, #167
License | MIT
Doc PR |