### PR TITLE
Remove an expected annotation space in test

### DIFF
--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -385,7 +385,7 @@ PHP
     /**
      * @var string|null an award won by or for this item
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      * @ApiProperty(iri="http://schema.org/award")
      */
     private $award;
@@ -396,7 +396,7 @@ PHP
     /**
      * @var string|null awards won by or for this item
      *
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="text",nullable=true)
      */
     protected $award;
 PHP


### PR DESCRIPTION
Not entirely sure what's going on, but:

1. According to [Travis build #561745529](https://travis-ci.org/api-platform/schema-generator/builds/561745529), the commits for PR https://github.com/api-platform/schema-generator/pull/151 have been merged into master.
2. The PR still shows as "open" (maybe not merged through GitHub?)
2. The merge commit on api-platform/schema-generator's master triggers [failed build #562900927](https://travis-ci.org/api-platform/schema-generator/builds/562900927)
3. [The build of my fork](https://travis-ci.org/baspeeters/schema-generator/builds/561745525) and the PR did both pass

The error in the build is because of a space in an `@ORM\Column` annotation during a test I had created (space after the comma in `(type="text",nullable=true)`).

Maybe something changed in the twig templates or a dependency that removed the space? It passed with a space on my fork as you can see.. I don't really know, but this fix now asserts the expected class property in the same way as every other test does (no space after that comma). master + this commit makes the tests pass:

- https://travis-ci.org/baspeeters/schema-generator/builds/569514224
- https://travis-ci.org/api-platform/schema-generator/builds/569522769

Sorry for the wall of text, but it was a bit mysterious why this happened. At least my proposed fix is simple :slightly_smiling_face: 