### PR TITLE
Fix tests: Put space back after comma between ORM annotation properties

### DIFF
--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -133,7 +133,7 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
 
                 if ($isColumnHasProperties) {
                     if (\count($annotArr) > 0) {
-                        $annotation .= implode(',', $annotArr);
+                        $annotation .= implode(', ', $annotArr);
                     }
                     $annotation .= ')';
                 }

--- a/tests/e2e/src/AppBundle/Entity/Person.php
+++ b/tests/e2e/src/AppBundle/Entity/Person.php
@@ -31,7 +31,7 @@ class Person
     /**
      * @var string|null Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/familyName")
      */
     private $familyName;
@@ -39,7 +39,7 @@ class Person
     /**
      * @var string|null Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/givenName")
      */
     private $givenName;
@@ -47,7 +47,7 @@ class Person
     /**
      * @var string|null an additional name for a Person, can be used for a middle name
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/additionalName")
      */
     private $additionalName;
@@ -55,7 +55,7 @@ class Person
     /**
      * @var string|null Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender.
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/gender")
      */
     private $gender;
@@ -71,7 +71,7 @@ class Person
     /**
      * @var \DateTimeInterface|null date of birth
      *
-     * @ORM\Column(type="date",nullable=true)
+     * @ORM\Column(type="date", nullable=true)
      * @ApiProperty(iri="http://schema.org/birthDate")
      * @Assert\Date
      */
@@ -80,7 +80,7 @@ class Person
     /**
      * @var string|null the telephone number
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/telephone")
      */
     private $telephone;
@@ -88,7 +88,7 @@ class Person
     /**
      * @var string|null email address
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/email")
      * @Assert\Email
      */
@@ -97,7 +97,7 @@ class Person
     /**
      * @var string|null URL of the item
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/url")
      * @Assert\Url
      */
@@ -106,7 +106,7 @@ class Person
     /**
      * @var string|null the job title of the person (for example, Financial Manager)
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/jobTitle")
      */
     private $jobTitle;

--- a/tests/e2e/src/AppBundle/Entity/PostalAddress.php
+++ b/tests/e2e/src/AppBundle/Entity/PostalAddress.php
@@ -30,7 +30,7 @@ class PostalAddress
     /**
      * @var string|null The country. For example, USA. You can also provide the two-letter \[ISO 3166-1 alpha-2 country code\](http://en.wikipedia.org/wiki/ISO\_3166-1).
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/addressCountry")
      */
     private $addressCountry;
@@ -38,7 +38,7 @@ class PostalAddress
     /**
      * @var string|null The locality. For example, Mountain View.
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/addressLocality")
      */
     private $addressLocality;
@@ -46,7 +46,7 @@ class PostalAddress
     /**
      * @var string|null The region. For example, CA.
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/addressRegion")
      */
     private $addressRegion;
@@ -54,7 +54,7 @@ class PostalAddress
     /**
      * @var string|null the post office box number for PO box addresses
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/postOfficeBoxNumber")
      */
     private $postOfficeBoxNumber;
@@ -62,7 +62,7 @@ class PostalAddress
     /**
      * @var string|null The postal code. For example, 94043.
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/postalCode")
      */
     private $postalCode;
@@ -70,7 +70,7 @@ class PostalAddress
     /**
      * @var string|null The street address. For example, 1600 Amphitheatre Pkwy.
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/streetAddress")
      */
     private $streetAddress;

--- a/tests/e2e/src/AppBundle/Entity/Thing.php
+++ b/tests/e2e/src/AppBundle/Entity/Thing.php
@@ -30,7 +30,7 @@ class Thing
     /**
      * @var string|null the name of the item
      *
-     * @ORM\Column(type="text",nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      * @ApiProperty(iri="http://schema.org/name")
      */
     private $name;


### PR DESCRIPTION
# Problem
1. Tests for `GenerateTypeCommand` were failing
2. Cause was a space missing after the comma between `@ORM\Column` parameters:

**Actual:**
```
* @ORM\Column(type="text",nullable=true)
```
**Expected:**
```
* @ORM\Column(type="text", nullable=true)
```

# Research
1. I had wrongly only adapted the test to this (never a good idea) in https://github.com/api-platform/schema-generator/pull/169 (closed)
2. @soyuka pointed out correctly that the fixtures in core did have the space
3. Started digging through the the git log....
4. Turns out the space was had actually been removed in the ORM annotations generator https://github.com/api-platform/schema-generator/commit/fc74945ec823243913bc45a97ffd8f0e278f351e making the produced files not in line with the core anymore

# Solution
1. Re-added the space to the annotations generator, just like how it worked before. This way I didn't "fix" by adapting the tests, and it should be an actual fix now.
2. Added the space in expected e2e entities file which means **these are now in line with the fixtures in core**, so imho they should be with the space.