### PR TITLE
Allow to specify entity name for generation

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -159,7 +159,7 @@ class TypesGenerator
 
             $comment = $type->get('rdfs:comment');
 
-            $class['name'] = $typeName;
+            $class['name'] = $typeConfig['doctrine']['entityName'] ?? $typeName;
             $class['label'] = $comment ? $comment->getValue() : '';
             $class['resource'] = $type;
             $class['config'] = $typeConfig;
@@ -400,7 +400,7 @@ class TypesGenerator
                 mkdir($classDir, 0777, true);
             }
 
-            $path = sprintf('%s%s.php', $classDir, $className);
+            $path = sprintf('%s%s.php', $classDir, $class['config']['doctrine']['entityName'] ?? $className);
             $generatedFiles[] = $path;
 
             file_put_contents(

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -158,6 +158,7 @@ final class TypesGeneratorConfiguration implements ConfigurationInterface
                                 ->addDefaultsIfNotSet()
                                 ->children()
                                     ->scalarNode('inheritanceMapping')->defaultNull()->info('The Doctrine inheritance mapping type (override the guessed one)')->end()
+                                    ->scalarNode('entityName')->defaultNull()->info('The doctrine entity name (default to the schema.org resource name)')->end()
                                 ->end()
                             ->end()
                             ->scalarNode('parent')->defaultFalse()->info('The parent class, set to false for a top level class')->end()

--- a/tests/Command/DumpConfigurationTest.php
+++ b/tests/Command/DumpConfigurationTest.php
@@ -143,6 +143,9 @@ config:
                 # The Doctrine inheritance mapping type (override the guessed one)
                 inheritanceMapping:   null
 
+                # The doctrine entity name (default to the schema.org resource name)
+                entityName:           null
+
             # The parent class, set to false for a top level class
             parent:               false
 

--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -402,4 +402,32 @@ PHP
 PHP
             , $creativeWork);
     }
+
+    public function testOverrideEntityName()
+    {
+        $outputDir = __DIR__.'/../../build/entity-name';
+        $config = __DIR__.'/../config/entity-name.yaml';
+
+        $this->fs->mkdir($outputDir);
+
+        $commandTester = new CommandTester(new GenerateTypesCommand());
+        $this->assertEquals(0, $commandTester->execute(['output' => $outputDir, 'config' => $config]));
+
+        $this->assertFileExists("$outputDir/AppBundle/Entity/CustomName.php");
+        $creativeWork = file_get_contents("$outputDir/AppBundle/Entity/CustomName.php");
+
+        $this->assertContains(<<<'PHP'
+/**
+ * The most generic kind of creative work, including books, movies, photographs, software programs, etc.
+ *
+ * @see http://schema.org/CreativeWork Documentation on Schema.org
+ *
+ * @ORM\Entity
+ * @ApiResource(iri="http://schema.org/CreativeWork")
+ */
+class CustomName
+{
+PHP
+            , $creativeWork);
+    }
 }

--- a/tests/config/entity-name.yaml
+++ b/tests/config/entity-name.yaml
@@ -1,0 +1,6 @@
+types:
+    CreativeWork:
+        doctrine:
+            entityName: CustomName
+        properties:
+            name: ~


### PR DESCRIPTION
```
| Q             | A
| ------------- | --- 
| Bug fix?      | no 
| New feature?  | yes 
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | -
| License       | MIT 
| Doc PR        | will do if accepted 
```

Hi,

While using the schema generator, the entity which will be generated will have the same name of the schema.org resource.

This is a proposal to allow to specify a different name.

Do you think it would be useful ?

And do you see any drawback by doing it this way ?

Thanks