### PR TITLE
non-int value in the execute command will be deprecated

### DIFF
--- a/src/Command/DumpConfigurationCommand.php
+++ b/src/Command/DumpConfigurationCommand.php
@@ -39,10 +39,12 @@ final class DumpConfigurationCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configuration = new TypesGeneratorConfiguration();
         $dumper = new YamlReferenceDumper();
         $output->writeln($dumper->dump($configuration));
+
+        return 0;
     }
 }

--- a/src/Command/ExtractCardinalitiesCommand.php
+++ b/src/Command/ExtractCardinalitiesCommand.php
@@ -44,7 +44,7 @@ final class ExtractCardinalitiesCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $schemaOrgFile = $input->getOption('schemaorg-file');
 
@@ -65,5 +65,7 @@ final class ExtractCardinalitiesCommand extends Command
         $result = $cardinalitiesExtractor->extract();
 
         $output->writeln(json_encode($result, JSON_PRETTY_PRINT));
+
+        return 0;
     }
 }

--- a/src/Command/GenerateTypesCommand.php
+++ b/src/Command/GenerateTypesCommand.php
@@ -67,7 +67,7 @@ final class GenerateTypesCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $defaultOutput = $this->defaultOutput ? realpath($this->defaultOutput) : null;
         $outputDir = $input->getArgument('output');
@@ -163,5 +163,7 @@ final class GenerateTypesCommand extends Command
 
         $entitiesGenerator = new TypesGenerator($twig, $logger, $graphs, $cardinalitiesExtractor, $goodRelationsBridge);
         $entitiesGenerator->generate($processedConfiguration);
+
+        return 0;
     }
 }


### PR DESCRIPTION
Related to symfony/symfony#33775

We can already apply this change without BC