### PR TITLE
Add support for entity operation annotations

### DIFF
--- a/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
+++ b/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
@@ -117,7 +117,6 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
         ];
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
+++ b/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
@@ -41,7 +41,7 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
         $arguments = [sprintf('iri="%s"', $resource->getUri())];
 
         if (isset($class['operations'])) {
-            $operations = $this->validateClassOperations((array)$class['operations']);
+            $operations = $this->validateClassOperations((array) $class['operations']);
             foreach ($operations as $operationTarget => $targetOperations) {
                 $targetArguments = [];
                 foreach ($targetOperations as $method => $methodConfig) {
@@ -59,9 +59,8 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
         return [sprintf('@ApiResource(%s)', implode(', ', $arguments))];
     }
 
-
     /**
-     * Verifies that the operations config is valid
+     * Verifies that the operations config is valid.
      *
      * @param array $operations
      *
@@ -77,9 +76,8 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
         return $resolver->resolve($operations);
     }
 
-
     /**
-     * Validates the individual method config for an item/collection operation annotation
+     * Validates the individual method config for an item/collection operation annotation.
      *
      * @param array $methodConfig
      *
@@ -105,7 +103,6 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
 
         return $resolver->resolve($methodConfig);
     }
-
 
     /**
      * {@inheritdoc}

--- a/tests/AnnotationGenerator/ApiPlatformCoreAnnotationGeneratorTest.php
+++ b/tests/AnnotationGenerator/ApiPlatformCoreAnnotationGeneratorTest.php
@@ -51,7 +51,7 @@ class ApiPlatformCoreAnnotationGeneratorTest extends TestCase
                 'WithOperations' => [
                     'resource' => new \EasyRdf_Resource('http://schema.org/WithOperations', $graph),
                     'operations' => [
-                        'item' => ['get' => ["route_name" => "api_about_get"]],
+                        'item' => ['get' => ['route_name' => 'api_about_get']],
                         'collection' => [],
                     ],
                 ],

--- a/tests/AnnotationGenerator/ApiPlatformCoreAnnotationGeneratorTest.php
+++ b/tests/AnnotationGenerator/ApiPlatformCoreAnnotationGeneratorTest.php
@@ -48,6 +48,13 @@ class ApiPlatformCoreAnnotationGeneratorTest extends TestCase
                     ],
                 ],
                 'MyEnum' => ['resource' => $myEnum],
+                'WithOperations' => [
+                    'resource' => new \EasyRdf_Resource('http://schema.org/WithOperations', $graph),
+                    'operations' => [
+                        'item' => ['get' => ["route_name" => "api_about_get"]],
+                        'collection' => [],
+                    ],
+                ],
             ]
         );
     }
@@ -55,6 +62,11 @@ class ApiPlatformCoreAnnotationGeneratorTest extends TestCase
     public function testGenerateClassAnnotations()
     {
         $this->assertSame(['@ApiResource(iri="http://schema.org/Res")'], $this->generator->generateClassAnnotations('Res'));
+    }
+
+    public function testGenerateClassAnnotationsWithOperations()
+    {
+        $this->assertSame(['@ApiResource(iri="http://schema.org/WithOperations", itemOperations={"get"={"route_name"="api_about_get"}}, collectionOperations={})'], $this->generator->generateClassAnnotations('WithOperations'));
     }
 
     public function testGenerateFieldAnnotations()


### PR DESCRIPTION
New version of PR #144, properly rebased on master,…

I've added the possibility to add the following to a type definition to support operation annotations…

    types:
        Person:
            operations:
                item:
                    <method>:
                        method: '<method>' # or…
                        router_name: '<route_name>'
                    # ...
                collection:
                    <method>:
                        method: '<method>' # or…
                        router_name: '<route_name>'
                    # ...

This will probably want documenting too, but not got time to do this right now.  I've made a reminder to do this if someone else doesn;t get to it before I do.