### PR TITLE
Enhance PHPUnit fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - export PATH="$PATH:$HOME/.composer/vendor/bin"
-  - wget -O phpunit.phar https://phar.phpunit.de/phpunit-6.5.phar
+  - wget -O phpunit.phar https://phar.phpunit.de/phpunit-7.5.phar
   - if [[ $coverage = 1 ]]; then mkdir -p build/logs; fi
   - if [[ $coverage = 1 ]]; then wget https://github.com/satooshi/php-coveralls/releases/download/v2.0.0/php-coveralls.phar; fi
   - if [[ $lint = 1 ]]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.10.0/php-cs-fixer.phar; fi

--- a/tests/AnnotationGenerator/ApiPlatformCoreAnnotationGeneratorTest.php
+++ b/tests/AnnotationGenerator/ApiPlatformCoreAnnotationGeneratorTest.php
@@ -28,7 +28,7 @@ class ApiPlatformCoreAnnotationGeneratorTest extends TestCase
      */
     private $generator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $graph = new \EasyRdf_Graph();
         $myEnum = new \EasyRdf_Resource('http://schema.org/MyEnum', $graph);

--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -28,7 +28,7 @@ class GenerateTypesCommandTest extends TestCase
      */
     private $fs;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->fs = new Filesystem();
     }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

# Changed log
- The `PHPUnit 7.x` requires `php-7.1.x` version at least, using the `PHPUnit 7.x` version instead on Travis CI build.
- According to the [PHPUnit fixture reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method will be `protected` with `void` type hint.
