### PR TITLE
Add missed type hint on src folder

### DIFF
--- a/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
+++ b/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
@@ -66,7 +66,7 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
      *
      * @return array
      */
-    private function validateClassOperations(array $operations)
+    private function validateClassOperations(array $operations): array
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(['item' => [], 'collection' => []]);
@@ -83,7 +83,7 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
      *
      * @return array
      */
-    private function validateClassOperationMethodConfig(array $methodConfig)
+    private function validateClassOperationMethodConfig(array $methodConfig): array
     {
         $resolver = new OptionsResolver();
 

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -474,7 +474,7 @@ class TypesGenerator
      *
      * @return array
      */
-    private function getParentClasses(\EasyRdf_Resource $resource, array $parentClasses = [])
+    private function getParentClasses(\EasyRdf_Resource $resource, array $parentClasses = []): array
     {
         if ([] === $parentClasses) {
             return $this->getParentClasses($resource, [$resource->getUri()]);
@@ -509,7 +509,7 @@ class TypesGenerator
      *
      * @return array
      */
-    private function createPropertiesMap(array $types)
+    private function createPropertiesMap(array $types): array
     {
         $typesAsString = [];
         $map = [];
@@ -592,7 +592,7 @@ class TypesGenerator
      *
      * @return array $class
      */
-    private function generateField(array $config, array $class, \EasyRdf_Resource $type, $typeName, $propertyName, \EasyRdf_Resource $property = null)
+    private function generateField(array $config, array $class, \EasyRdf_Resource $type, $typeName, $propertyName, \EasyRdf_Resource $property = null): array
     {
         $typeConfig = $config['types'][$typeName] ?? null;
         $typesDefined = !empty($config['types']);


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

# Changed log
- Add native type hints for every PHP class methods on `src` folder.