### PR TITLE
Missing package `symfony/config` update to SF5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "friendsofphp/php-cs-fixer": "^2.15",
         "league/html-to-markdown": "^4.0",
         "psr/log": "^1.0",
-        "symfony/config": "^3.3 || ^4.0",
+        "symfony/config": "^3.3 || ^4.0 || ^5.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "twig/twig": "^1.35 || ^2.0 || ^3.0"


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Package `symfony/config` in `composer.json` doesnt support Symfony 5.0.
It seems to be a forgot error when updating other dependencies to SF5.