### PR TITLE
Singularize/pluralize 3+ letter long words only in the property names

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -653,7 +653,7 @@ class TypesGenerator
             }
 
             $class['fields'][$propertyName] = [
-                'name' => $isArray ? Inflector::pluralize($propertyName) : Inflector::singularize($propertyName),
+                'name' => $this->getFieldName($propertyName, $isArray),
                 'resource' => $property,
                 'range' => $ranges[0],
                 'cardinality' => $cardinality,
@@ -872,5 +872,19 @@ class TypesGenerator
             new NullCacheManager()
         );
         $runner->fix();
+    }
+
+    private function getFieldName(string $propertyName, bool $isArray): string
+    {
+        $snakeProperty = preg_replace('/([A-Z])/', '_$1', $propertyName);
+        $exploded = explode('_', $snakeProperty);
+
+        if (2 < \strlen($word = $exploded[\count($exploded) - 1])) {
+            $exploded[\count($exploded) - 1] = $isArray ? Inflector::pluralize($word) : Inflector::singularize($word);
+
+            return implode('', $exploded);
+        }
+
+        return $propertyName;
     }
 }

--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -175,6 +175,7 @@ PHP
         $this->assertEquals(0, $commandTester->execute(['output' => $outputDir, 'config' => $config]));
 
         $person = file_get_contents("$outputDir/AppBundle/Entity/Person.php");
+        $this->assertStringContainsString('private $sameAs;', $person);
         $this->assertStringContainsString('public function getId(', $person);
         $this->assertStringNotContainsString('function setId(', $person);
         $this->assertStringContainsString('public function getName(', $person);
@@ -182,6 +183,7 @@ PHP
         $this->assertStringContainsString('public function getFriends(', $person);
         $this->assertStringNotContainsString('function addFriend(', $person);
         $this->assertStringNotContainsString('function removeFriend(', $person);
+        $this->assertStringNotContainsString('function setSameAs(', $person);
     }
 
     public function testGeneratedId(): void

--- a/tests/config/readable-writable.yaml
+++ b/tests/config/readable-writable.yaml
@@ -4,3 +4,4 @@ types:
       name: { writable: false }
       familyName: { readable: false }
       friends: { range: "Person", cardinality: (0..*), writable: false }
+      sameAs: { writable: false }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #162
| License       | MIT
| Doc PR        | 

Fixing an issue that makes some words in property names being singularized/pluralized, when they actually are not nouns (e.g., _same as_ in the Thing schema should not be singularized in _same a_).
To fix this, we separate the words in the property name and check that the last word is more than 2 letter long [1]. If it is, then it is singularized/pluralized, otherwise it remains as is. The rest is left unchanged.

---

[1]: in English, two-letter long words are in majority acronyms, and the rest are not nouns. See https://en.wikibooks.org/wiki/Scrabble/Two_Letter_Words