### PR TITLE
Ask before adding all Schema.org's vocabulary

### DIFF
--- a/src/Command/GenerateTypesCommand.php
+++ b/src/Command/GenerateTypesCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Yaml\Parser;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
@@ -119,6 +120,13 @@ final class GenerateTypesCommand extends Command
             $config = $parser->parse(file_get_contents(self::DEFAULT_CONFIG_FILE));
             unset($parser);
         } else {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion('Your project has no config file. The entire Schema.org vocabulary will be built.'.PHP_EOL.'Continue? [yN]', false);
+
+            if (!$helper->ask($input, $output, $question)) {
+                return 0;
+            }
+
             $config = [];
         }
 

--- a/tests/Command/GenerateTypesCommandTest.php
+++ b/tests/Command/GenerateTypesCommandTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\SchemaGenerator\Tests\Command;
 
 use ApiPlatform\SchemaGenerator\Command\GenerateTypesCommand;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -433,5 +434,18 @@ PHP
     protected $award;
 PHP
             , $creativeWork);
+    }
+
+    public function testGenerationWithoutConfigFileQuestion(): void
+    {
+        // No config file is given.
+        $application = new Application();
+        $application->add(new GenerateTypesCommand());
+
+        $command = $application->find('generate-types');
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['n']);
+        self::assertEquals(0, $commandTester->execute([]));
+        $this->assertRegExp('/The entire Schema\.org vocabulary will be built/', $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #146
| License       | MIT
| Doc PR        | n/a

When the project has no schema configuration, the entire Schema.org vocabulary is imported in the project. This situation, quite rare, is most likely not wanted. Ask first the developer it's really what they want.

![Steam Ham meme with captions: Schema.org's vocabulary localized entirely in your project?](https://user-images.githubusercontent.com/7600265/72157871-35a20b80-33b9-11ea-91c7-c23f5d60c5c0.png)