### PR TITLE
Fix incorrect logic of interface mappings

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -438,7 +438,7 @@ class TypesGenerator
             }
         }
 
-        if (count($interfaceMappings) > 0 && $config['doctrine']['resolveTargetEntityConfigPath']) {
+        if (\count($interfaceMappings) > 0 && $config['doctrine']['resolveTargetEntityConfigPath']) {
             $file = $config['output'].'/'.$config['doctrine']['resolveTargetEntityConfigPath'];
             $dir = \dirname($file);
             if (!file_exists($dir)) {

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -438,7 +438,7 @@ class TypesGenerator
             }
         }
 
-        if (!$interfaceMappings && $config['doctrine']['resolveTargetEntityConfigPath']) {
+        if (count($interfaceMappings) > 0 && $config['doctrine']['resolveTargetEntityConfigPath']) {
             $file = $config['output'].'/'.$config['doctrine']['resolveTargetEntityConfigPath'];
             $dir = \dirname($file);
             if (!file_exists($dir)) {


### PR DESCRIPTION
The following commit https://github.com/api-platform/schema-generator/commit/64ae94b99e4fe90ace96bd30c4d4a135ec7b0eee introduced an inversion of the logic for this condition:
```
!empty($interfaceMappings)
```
became:
```
!$interfaceMappings
```

The result means that the ```ResolveTargetEntityListener``` doctrine.xml config is never generated when interfaces are used.

