### PR TITLE
Add Doctrine relationship annotations of OnDelete and for Cascade persistance

### DIFF
--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -94,6 +94,15 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
                 case 'Text':
                 case 'URL':
                     $type = 'text';
+                    break;               
+                case 'Array':
+                    $type = 'array';
+                    break;
+                case 'SimpleArray':
+                    $type = 'simple_array';
+                    break;
+                case 'JsonArray':
+                    $type = 'json_array';
                     break;
             }
         }

--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -149,54 +149,58 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
             }
             $annotations[] = sprintf('@ORM\Embedded(class="%s"%s)', $this->getRelationName($field['range']), $columnPrefix);
         } else {
+            $cascade = ($field['cascade'] ?? null ? sprintf(', cascade=%s', $field['cascade']): null);
             switch ($field['cardinality']) {
                 case CardinalitiesExtractor::CARDINALITY_0_1:
-                    $annotations[] = sprintf('@ORM\OneToOne(targetEntity="%s")', $this->getRelationName($field['range']));
+                    $annotations[] = sprintf('@ORM\OneToOne(targetEntity="%s"%s)', $this->getRelationName($field['range'], $cascade));
                     break;
                 case CardinalitiesExtractor::CARDINALITY_1_1:
-                    $annotations[] = sprintf('@ORM\OneToOne(targetEntity="%s")', $this->getRelationName($field['range']));
+                    $annotations[] = sprintf('@ORM\OneToOne(targetEntity="%s"%s)', $this->getRelationName($field['range'], $cascade));
                     $annotations[] = '@ORM\JoinColumn(nullable=false)';
                     break;
                 case CardinalitiesExtractor::CARDINALITY_UNKNOWN:
                 case CardinalitiesExtractor::CARDINALITY_N_0:
                     if ($field['inversedBy'] ?? false) {
-                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s", inversedBy="%s")', $this->getRelationName($field['range']), $field['inversedBy']);
+                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s", inversedBy="%s"%s)', $this->getRelationName($field['range']), $field['inversedBy'], $cascade);
                     } else {
-                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s")', $this->getRelationName($field['range']));
+                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s"%s)', $this->getRelationName($field['range']), $cascade);
                     }
                     break;
                 case CardinalitiesExtractor::CARDINALITY_N_1:
                     if ($field['inversedBy'] ?? false) {
-                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s", inversedBy="%s")', $this->getRelationName($field['range']), $field['inversedBy']);
+                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s", inversedBy="%s"%s)', $this->getRelationName($field['range']), $field['inversedBy'], $cascade);
                     } else {
-                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s")', $this->getRelationName($field['range']));
+                        $annotations[] = sprintf('@ORM\ManyToOne(targetEntity="%s"%s)', $this->getRelationName($field['range']), $cascade);
                     }
                     $annotations[] = '@ORM\JoinColumn(nullable=false)';
                     break;
                 case CardinalitiesExtractor::CARDINALITY_0_N:
                     if ($field['mappedBy'] ?? false) {
-                        $annotations[] = sprintf('@ORM\OneToMany(targetEntity="%s", mappedBy="%s")', $this->getRelationName($field['range']), $field['mappedBy']);
+                        $annotations[] = sprintf('@ORM\OneToMany(targetEntity="%s", mappedBy="%s"%s)', $this->getRelationName($field['range']), $field['mappedBy'], $cascade);
                     } else {
-                        $annotations[] = sprintf('@ORM\ManyToMany(targetEntity="%s")', $this->getRelationName($field['range']));
+                        $annotations[] = sprintf('@ORM\ManyToMany(targetEntity="%s"%s)', $this->getRelationName($field['range']), $cascade);
                     }
                     $name = $field['relationTableName'] ? sprintf('name="%s", ', $field['relationTableName']) : '';
                     $annotations[] = '@ORM\JoinTable('.$name.'inverseJoinColumns={@ORM\JoinColumn(unique=true)})';
                     break;
                 case CardinalitiesExtractor::CARDINALITY_1_N:
                     if ($field['mappedBy'] ?? false) {
-                        $annotations[] = sprintf('@ORM\OneToMany(targetEntity="%s", mappedBy="%s")', $this->getRelationName($field['range']), $field['mappedBy']);
+                        $annotations[] = sprintf('@ORM\OneToMany(targetEntity="%s", mappedBy="%s"%s)', $this->getRelationName($field['range']), $field['mappedBy'], $cascade);
                     } else {
-                        $annotations[] = sprintf('@ORM\ManyToMany(targetEntity="%s")', $this->getRelationName($field['range']));
+                        $annotations[] = sprintf('@ORM\ManyToMany(targetEntity="%s"%s)', $this->getRelationName($field['range']), $cascade);
                     }
                     $name = $field['relationTableName'] ? sprintf('name="%s", ', $field['relationTableName']) : '';
                     $annotations[] = '@ORM\JoinTable('.$name.'inverseJoinColumns={@ORM\JoinColumn(nullable=false, unique=true)})';
                     break;
                 case CardinalitiesExtractor::CARDINALITY_N_N:
-                    $annotations[] = sprintf('@ORM\ManyToMany(targetEntity="%s")', $this->getRelationName($field['range']));
+                    $annotations[] = sprintf('@ORM\ManyToMany(targetEntity="%s"%s)', $this->getRelationName($field['range']), $cascade);
                     if ($field['relationTableName']) {
                         $annotations[] = sprintf('@ORM\JoinTable(name="%s")', $field['relationTableName']);
                     }
                     break;
+            }
+            if ($field['onDelete'] ?? null) {
+                $annotations[] = sprintf('@ORM\OnDelete(cascade="%s")', $field['onDelete']);
             }
         }
 

--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -95,15 +95,6 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
                 case 'URL':
                     $type = 'text';
                     break;               
-                case 'Array':
-                    $type = 'array';
-                    break;
-                case 'SimpleArray':
-                    $type = 'simple_array';
-                    break;
-                case 'JsonArray':
-                    $type = 'json';
-                    break;
             }
         }
 

--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -102,7 +102,7 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
                     $type = 'simple_array';
                     break;
                 case 'JsonArray':
-                    $type = 'json_array';
+                    $type = 'json';
                     break;
             }
         }

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -668,6 +668,8 @@ class TypesGenerator
                 'columnPrefix' => $columnPrefix,
                 'mappedBy' => $propertyConfig['mappedBy'] ?? null,
                 'inversedBy' => $propertyConfig['inversedBy'] ?? null,
+                'cascade' => $propertyConfig['cascade'] ?? null,
+                'onDelete' => $propertyConfig['cascade'] ?? null,
                 'isId' => false,
             ];
 

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -669,7 +669,7 @@ class TypesGenerator
                 'mappedBy' => $propertyConfig['mappedBy'] ?? null,
                 'inversedBy' => $propertyConfig['inversedBy'] ?? null,
                 'cascade' => $propertyConfig['cascade'] ?? null,
-                'onDelete' => $propertyConfig['cascade'] ?? null,
+                'onDelete' => $propertyConfig['onDelete'] ?? null,
                 'isId' => false,
             ];
 

--- a/src/TypesGeneratorConfiguration.php
+++ b/src/TypesGeneratorConfiguration.php
@@ -194,6 +194,8 @@ final class TypesGeneratorConfiguration implements ConfigurationInterface
                                         ->end()
                                         ->scalarNode('mappedBy')->defaultNull()->info('The doctrine mapped by attribute')->example('partOfSeason')->end()
                                         ->scalarNode('inversedBy')->defaultNull()->info('The doctrine inversed by attribute')->example('episodes')->end()
+                                        ->scalarNode('onDelete')->defaultNull()->info('Action on parent entity delete')->example('SET NULL or CASCADE')->end()
+                                        ->scalarNode('cascade')->defaultNull()->info('Persistance strategy')->example('{"PERSIST","REMOVE"}')->end()
                                         ->booleanNode('readable')->defaultTrue()->info('Is the property readable?')->end()
                                         ->booleanNode('writable')->defaultTrue()->info('Is the property writable?')->end()
                                         ->booleanNode('nullable')->defaultTrue()->info('Is the property nullable?')->end()


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Bug fix?      | no 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#...
```
SalesTax:
  properties:
    taxComponent:
      range: TaxComponent
      cardinality: (1..*)
      mappedBy: salesTax
      cascade: '{"PERSIST, "REMOVE"}'

TaxComponent:
  properties:
    salesTax:
      range: SalesTax
      cardinality:  (*..1)
      inversedBy: taxComponent
      onDelete: "CASCADE"
```

Adds to parent 
```@ORM\OneToMany(targetEntity="App\Entity\Vat\TaxComponent", mappedBy="salesTax", cascade={"PERSIST, "REMOVE"})```

Adds to child 
```@ORM\OnDelete(cascade="CASCADE") or SET NULL to child relationships.```
