### PR TITLE
Fix #331: command extract-cardinalities uses reserved option 'v'

### DIFF
--- a/src/Command/ExtractCardinalitiesCommand.php
+++ b/src/Command/ExtractCardinalitiesCommand.php
@@ -37,7 +37,7 @@ final class ExtractCardinalitiesCommand extends Command
         $this
             ->setName('extract-cardinalities')
             ->setDescription('Extract properties\' cardinality')
-            ->addOption('vocabulary-file', 'v', InputOption::VALUE_REQUIRED, 'The path or URL of the vocabulary RDF file to use.', TypesGeneratorConfiguration::SCHEMA_ORG_URI)
+            ->addOption('vocabulary-file', 's', InputOption::VALUE_REQUIRED, 'The path or URL of the vocabulary RDF file to use.', TypesGeneratorConfiguration::SCHEMA_ORG_URI)
             ->addOption('cardinality-file', 'g', InputOption::VALUE_REQUIRED, 'The path or URL of the OWL file containing the cardinality definitions.', TypesGeneratorConfiguration::GOOD_RELATIONS_URI)
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #331 
| License       | MIT
| Doc PR        | Not needed, the option is not documented

Symfony commands have a reserved option 'v' for verbosity, so command
can't have that option themselves. And since the shortcut for
cardinality-file has stayed the same, revert the shortcut for
vocabulary-file back to 's'.
