### PR TITLE
fix: Update assertion constraint for Date, DateTime and Time to Type(DateTimeInterface) for compatibility with Symfony 5.

### DIFF
--- a/src/AnnotationGenerator/ConstraintAnnotationGenerator.php
+++ b/src/AnnotationGenerator/ConstraintAnnotationGenerator.php
@@ -44,13 +44,9 @@ final class ConstraintAnnotationGenerator extends AbstractAnnotationGenerator
                     $asserts[] = '@Assert\Url';
                     break;
                 case 'http://schema.org/Date':
-                    $asserts[] = '@Assert\Date';
-                    break;
                 case 'http://schema.org/DateTime':
-                    $asserts[] = '@Assert\DateTime';
-                    break;
                 case 'http://schema.org/Time':
-                    $asserts[] = '@Assert\Time';
+                    $asserts[] = '@Assert\Type("\DateTimeInterface")';
                     break;
             }
 


### PR DESCRIPTION
The ability to use Assert\Date to validate DateTime objects was deprecated on Symfony 4.2, and on Symfony 5.0 it was removed altogether: https://github.com/symfony/symfony/commit/a052378bdd1c94a7a4ddfb826c18215e1a3e0301