### PR TITLE
fix: Moves php cs fixer to the dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "ext-json": "*",
         "doctrine/inflector": "^1.4.3 || ^2.0",
         "easyrdf/easyrdf": "^1.1",
-        "friendsofphp/php-cs-fixer": "^2.15",
         "league/html-to-markdown": "^4.9",
         "psr/log": "^1.0",
         "symfony/config": "^5.2",
@@ -34,6 +33,7 @@
     "require-dev": {
         "api-platform/core": "^2.5",
         "doctrine/orm": "^2.7",
+        "friendsofphp/php-cs-fixer": "^2.15",
         "myclabs/php-enum": "^1.7",
         "symfony/doctrine-bridge": "^5.2",
         "symfony/phpunit-bridge": "^5.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | https://github.com/api-platform/schema-generator/issues/330
| License       | MIT
| Doc PR        | N/A

This change should solve my big problem : I cannot move to php cs fixer v3