### PR TITLE
fix: Add support for interface namespaces

### DIFF
--- a/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
+++ b/src/AnnotationGenerator/DoctrineOrmAnnotationGenerator.php
@@ -289,6 +289,14 @@ final class DoctrineOrmAnnotationGenerator extends AbstractAnnotationGenerator
         $class = $this->classes[$rangeName];
 
         if (isset($class['interfaceName'])) {
+            if (isset($this->config['types'][$rangeName]['namespaces']['interface'])) {
+	            return sprintf('%s\\%s', $this->config['types'][$class['name']]['namespaces']['interface'], $class['interfaceName']);
+	        }
+
+	        if (isset($this->config['namespaces']['interface'])) {
+	            return sprintf('%s\\%s', $this->config['namespaces']['interface'], $class['interfaceName']);
+	        }
+
             return $class['interfaceName'];
         }
 


### PR DESCRIPTION
When enabling interfaces in the schema-generator, they go in a separate namespace (can be customized). the DoctrineOrmAnnotationGenerator correctly maps the namespace of any class except when it's an interface.

| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes