### PR TITLE
fix: #342 Undefined index: "abstract" error

### DIFF
--- a/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
+++ b/src/AnnotationGenerator/ApiPlatformCoreAnnotationGenerator.php
@@ -35,7 +35,7 @@ final class ApiPlatformCoreAnnotationGenerator extends AbstractAnnotationGenerat
     public function generateClassAnnotations(string $className): array
     {
         $class = $this->classes[$className];
-        if (\array_key_exists('abstract', $class)) {
+        if ($class['abstract'] ?? false) {
             return [];
         }
         $resource = $class['resource'];

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -955,7 +955,7 @@ class TypesGenerator
 
         // to keep compatibility with both versions of php-cs-fixer: 2.x and 3.x
         // ruleset object must be created depending on which class is available
-        $rulesetClass = class_exists('PhpCsFixer\RuleSet\RuleSet') ? Ruleset::class : LegacyRuleSet::class;
+        $rulesetClass = class_exists(RuleSet::class) ? Ruleset::class : LegacyRuleSet::class;
         $fixers = (new FixerFactory())
             ->registerBuiltInFixers()
             ->useRuleSet(new $rulesetClass([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | current stable version branch for bug fixes
| Tickets       | #342 
| License       | MIT

Replaced `if ($class['abstract'])` with `if (\array_key_exists('abstract', $class))` in `ApiPlatformCoreAnnotationGeneratorTest::testGenerateClassAnnotations` on line `38`