### PR TITLE
fix: Check if key is set to prevent warning

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -256,9 +256,6 @@ class TypesGenerator
                     }
 
                     foreach ($this->getParentClasses($type) as $typeInHierarchy) {
-                        if (!isset($propertiesMap[$typeInHierarchy->getUri()])) {
-                    		continue;
-                    	}
                         foreach ($propertiesMap[$typeInHierarchy->getUri()] ?? [] as $property) {
                             if ($key !== $property->localName()) {
                                 continue;


### PR DESCRIPTION
When the properitesMap array gets iterated to generate the fields, it happens that the uri of the typeInHierarchy is not a key of the said array; this triggers a PHP Warning:  Undefined array key. Seems to happen only for custom classes definition though. This does not prevent the command to run, this is really not critical.

| Q             | A
| ------------- | ---
| Branch?       | main 
| License       | MIT
| Doc PR        | api-platform/docs#
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
