### PR TITLE
fix: Skip error logging of missing Enum class

### DIFF
--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -294,7 +294,7 @@ class TypesGenerator
 
         // Second pass
         foreach ($classes as &$class) {
-            if ($class['parent'] && $class['parent'] != "Enum") {
+            if ($class['parent'] && $class['parent'] !== 'Enum') {
                 if (isset($classes[$class['parent']])) {
                     $classes[$class['parent']]['hasChild'] = true;
                     $class['parentHasConstructor'] = $classes[$class['parent']]['hasConstructor'];


### PR DESCRIPTION
When using Enumeration types, for each different type an [error] message will show in the console reading as the following:
The type "Enum" (parent of "http://schema.org/DayOfWeek") doesn't exist
This is because the Enumeration class is custom and handled differently from the others; it uses MyCLabs\Enum\Enum. When the types are being generated, there is a check that assigns the parent 'Enum' and adds MyCLabs\Enum\Enum::class in the uses array if the type is a subclass of http://schema.org/Enumeration.
So when the command goes in the second pass, it checks for the parent of the given class (if any), if there is one, it checks if it has a constructor and tells the parent it has child; if the parent class isn't in the "all" classes array, it logs an error to let the user know he must add this class in his schema... but this is not required for the Enum type since it's custom and extending a class from a package; thus making this seems like an error to the user when actually there is none.

| Q             | A
| ------------- | ---
| Branch?       | current stable
| Tickets       | #317 
| License       | MIT
| Doc PR        | api-platform/docs#
| Bug fix?      | yes (kinda)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
