### PR TITLE
feat: add api(Resource/Property)Arguments to types and vocabulary

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
                 relationTableName: ?string,
                 cardinality: string,
                 ormColumn: array<string, string|string[]>,
-                security: ?string,
+                apiPropertyArguments: array{},
                 groups: string[],
                 mappedBy: ?string,
                 inversedBy: ?string,
@@ -34,14 +34,14 @@ parameters:
                 parent: false|string,
                 guessFrom: string,
                 operations: array<string, array<string, string[]>>,
-                security: ?string,
+                apiResourceArguments: array{},
                 allProperties: boolean,
                 properties: array<string, PropertyConfiguration>
             }
         '''
         Configuration: '''
             array{
-                 vocabularies: array{uri: string, format: string, allTypes: ?boolean}[],
+                 vocabularies: array{uri: string, format: string, allTypes: ?boolean, apiResourceArguments: array{}}[],
                  vocabularyNamespace: string,
                  relations: string[],
                  debug: boolean,

--- a/src/AttributeGenerator/ApiPlatformCoreAttributeGenerator.php
+++ b/src/AttributeGenerator/ApiPlatformCoreAttributeGenerator.php
@@ -46,8 +46,8 @@ final class ApiPlatformCoreAttributeGenerator extends AbstractAttributeGenerator
         if ($class->rdfType()) {
             $arguments['iri'] = $class->rdfType();
         }
-        if ($class->security) {
-            $arguments['security'] = $class->security;
+        if ($class->apiResourceArguments) {
+            $arguments = array_merge($arguments, $class->apiResourceArguments);
         }
 
         if ($class->operations) {
@@ -98,8 +98,8 @@ final class ApiPlatformCoreAttributeGenerator extends AbstractAttributeGenerator
             $arguments['iri'] = $property->rdfType();
         }
 
-        if ($property->security) {
-            $arguments['security'] = $property->security;
+        if ($property->apiPropertyArguments) {
+            $arguments = array_merge($arguments, $property->apiPropertyArguments);
         }
 
         return $property->isCustom ? [] : [new Attribute('ApiProperty', $arguments)];

--- a/src/ClassMutator/ClassMutatorInterface.php
+++ b/src/ClassMutator/ClassMutatorInterface.php
@@ -17,6 +17,6 @@ use ApiPlatform\SchemaGenerator\Model\Class_;
 
 interface ClassMutatorInterface
 {
-    // @phpstan-ignore-next-line
+    // @phpstan-ignore-next-line dynamic context
     public function __invoke(Class_ $class, array $context): void;
 }

--- a/src/Model/Class_.php
+++ b/src/Model/Class_.php
@@ -44,7 +44,8 @@ abstract class Class_
     public bool $isAbstract = false;
     public bool $hasChild = false;
     public bool $isEmbeddable = false;
-    public ?string $security = null;
+    // @phpstan-ignore-next-line dynamic array
+    public array $apiResourceArguments = [];
     /** @var array<string, array<string, string[]|null>> */
     public array $operations = [];
 

--- a/src/Model/Property.php
+++ b/src/Model/Property.php
@@ -51,7 +51,8 @@ abstract class Property
     public ?string $adderRemoverTypeHint = null;
     /** @var string[] */
     public array $groups = [];
-    public ?string $security = null;
+    // @phpstan-ignore-next-line dynamic array
+    public array $apiPropertyArguments = [];
     /** @var Attribute[] */
     private array $attributes = [];
     /** @var string[] */

--- a/src/PropertyGenerator/PropertyGeneratorInterface.php
+++ b/src/PropertyGenerator/PropertyGeneratorInterface.php
@@ -21,7 +21,7 @@ interface PropertyGeneratorInterface
     /**
      * @param Configuration $config
      */
-    // @phpstan-ignore-next-line
+    // @phpstan-ignore-next-line dynamic context
     public function __invoke(
         string $name,
         array $config,

--- a/src/Schema/Generator.php
+++ b/src/Schema/Generator.php
@@ -34,12 +34,12 @@ final class Generator
     public function generate(array $configuration, OutputInterface $output, SymfonyStyle $io): void
     {
         $graphs = [];
-        foreach ($configuration['vocabularies'] as $vocab) {
-            $graph = new RdfGraph($vocab['uri']);
-            if (0 === strpos($vocab['uri'], 'http://') || 0 === strpos($vocab['uri'], 'https://')) {
-                $graph->load($vocab['uri'], $vocab['format']);
+        foreach ($configuration['vocabularies'] as $uri => $vocab) {
+            $graph = new RdfGraph($uri);
+            if (0 === strpos($uri, 'http://') || 0 === strpos($uri, 'https://')) {
+                $graph->load($uri, $vocab['format']);
             } else {
-                $graph->parseFile($vocab['uri'], $vocab['format']);
+                $graph->parseFile($uri, $vocab['format']);
             }
 
             $graphs[] = $graph;

--- a/src/Schema/PropertyGenerator/PropertyGenerator.php
+++ b/src/Schema/PropertyGenerator/PropertyGenerator.php
@@ -163,7 +163,7 @@ final class PropertyGenerator implements PropertyGeneratorInterface
         $schemaProperty->mappedBy = $propertyConfig['mappedBy'] ?? null;
         $schemaProperty->inversedBy = $propertyConfig['inversedBy'] ?? null;
         $schemaProperty->groups = $propertyConfig['groups'] ?? [];
-        $schemaProperty->security = $propertyConfig['security'] ?? null;
+        $schemaProperty->apiPropertyArguments = $propertyConfig['apiPropertyArguments'] ?? [];
 
         return $schemaProperty;
     }

--- a/src/TypesGenerator.php
+++ b/src/TypesGenerator.php
@@ -245,10 +245,11 @@ class TypesGenerator
         }
 
         $typeConfig = $config['types'][$typeName] ?? null;
+        $vocabConfig = $config['vocabularies'][$type->getGraph()->getUri()] ?? null;
         $parent = $typeConfig['parent'] ?? null;
         $class = new SchemaClass($typeName, $type, $parent);
         $class->operations = $typeConfig['operations'] ?? [];
-        $class->security = $typeConfig['security'] ?? null;
+        $class->apiResourceArguments = array_merge($vocabConfig['apiResourceArguments'] ?? [], $typeConfig['apiResourceArguments'] ?? []);
 
         if ($class->isEnum()) {
             (new SchemaEnumClassMutator(
@@ -430,13 +431,7 @@ class TypesGenerator
         $allTypes = [];
 
         foreach ($graphs as $graph) {
-            $vocabAllTypes = $config['allTypes'];
-            foreach ($config['vocabularies'] as $vocab) {
-                if ($graph->getUri() !== $vocab['uri']) {
-                    continue;
-                }
-                $vocabAllTypes = $vocab['allTypes'] ?? $vocabAllTypes;
-            }
+            $vocabAllTypes = $config['vocabularies'][$graph->getUri()]['allTypes'] ?? $config['allTypes'];
             foreach (self::$classTypes as $classType) {
                 foreach ($graph->allOfType($classType) as $type) {
                     if ($type->isBNode()) {

--- a/tests/AttributeGenerator/ApiPlatformCoreAttributeGeneratorTest.php
+++ b/tests/AttributeGenerator/ApiPlatformCoreAttributeGeneratorTest.php
@@ -74,9 +74,9 @@ class ApiPlatformCoreAttributeGeneratorTest extends TestCase
 
         yield 'with short name' => [(new SchemaClass('WithShortName', new RdfResource('https://schema.org/DifferentLocalName', new RdfGraph()))), [new Attribute('ApiResource', ['shortName' => 'DifferentLocalName', 'iri' => 'https://schema.org/DifferentLocalName'])]];
 
-        $class = new SchemaClass('WithSecurity', new RdfResource('https://schema.org/WithSecurity', new RdfGraph()));
-        $class->security = "is_granted('ROLE_USER')";
-        yield 'with security' => [$class, [new Attribute('ApiResource', ['iri' => 'https://schema.org/WithSecurity', 'security' => "is_granted('ROLE_USER')"])]];
+        $class = new SchemaClass('WithApiResourceArguments', new RdfResource('https://schema.org/WithApiResourceArguments', new RdfGraph()));
+        $class->apiResourceArguments = ['security' => "is_granted('ROLE_USER')"];
+        yield 'with ApiResource arguments' => [$class, [new Attribute('ApiResource', ['iri' => 'https://schema.org/WithApiResourceArguments', 'security' => "is_granted('ROLE_USER')"])]];
     }
 
     /**
@@ -93,10 +93,10 @@ class ApiPlatformCoreAttributeGeneratorTest extends TestCase
         $property->resource = new RdfResource('https://schema.org/prop');
         yield 'classical' => [$property, [new Attribute('ApiProperty', ['iri' => 'https://schema.org/prop'])]];
 
-        $property = new Property('WithSecurity');
-        $property->resource = new RdfResource('https://schema.org/WithSecurity');
-        $property->security = "is_granted('ROLE_ADMIN')";
-        yield 'with security' => [$property, [new Attribute('ApiProperty', ['iri' => 'https://schema.org/WithSecurity', 'security' => "is_granted('ROLE_ADMIN')"])]];
+        $property = new Property('WithApiPropertyArguments');
+        $property->resource = new RdfResource('https://schema.org/WithApiPropertyArguments');
+        $property->apiPropertyArguments = ['security' => "is_granted('ROLE_ADMIN')"];
+        yield 'with ApiProperty arguments' => [$property, [new Attribute('ApiProperty', ['iri' => 'https://schema.org/WithApiPropertyArguments', 'security' => "is_granted('ROLE_ADMIN')"])]];
     }
 
     public function testGenerateCustomPropertyAttributes(): void

--- a/tests/Command/DumpConfigurationTest.php
+++ b/tests/Command/DumpConfigurationTest.php
@@ -35,16 +35,19 @@ config:
     vocabularies:
 
         # Prototype
-        -
+        uri:
 
             # RDF vocabulary to use
-            uri:                  'https://schema.org/version/latest/schemaorg-current-https.rdf' # Example: 'https://schema.org/version/latest/schemaorg-current-https.rdf'
+            uri:                  ~ # Example: 'https://schema.org/version/latest/schemaorg-current-https.rdf'
 
             # RDF vocabulary format
             format:               null # Example: rdfxml
 
             # Generate all types for this vocabulary, even if an explicit configuration exists. If allTypes is enabled globally, it can be disabled for this particular vocabulary
             allTypes:             null
+
+            # Arguments to add to ApiResource for all the classes generated for this vocabulary
+            apiResourceArguments: []
 
     # Namespace of the vocabulary to import
     vocabularyNamespace:  'https://schema.org/' # Example: 'http://www.w3.org/ns/activitystreams#'
@@ -180,8 +183,8 @@ config:
             # Operations for the class
             operations:           []
 
-            # Security directive for the class
-            security:             null
+            # Arguments to add to ApiResource (for instance security)
+            apiResourceArguments: []
 
             # Import all existing properties
             allProperties:        false
@@ -205,8 +208,8 @@ config:
                     # The doctrine column attribute content
                     ormColumn:            [] # Example: '{type: "decimal", precision: 5, scale: 1, options: {comment: "my comment"}}'
 
-                    # Security directive for the property
-                    security:             null
+                    # Arguments to add to ApiProperty (for instance security)
+                    apiPropertyArguments: []
 
                     # Symfony Serialization Groups
                     groups:               []

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -447,6 +447,20 @@ PHP
     private ?string $content = null;
 PHP
             , $object);
+
+        $page = file_get_contents("$outputDir/App/Entity/Page.php");
+
+        $this->assertStringContainsString(<<<'PHP'
+/**
+ * A Web Page.
+ *
+ * @see http://www.w3.org/ns/activitystreams#Page
+ */
+#[ORM\Entity]
+#[ApiResource(iri: 'http://www.w3.org/ns/activitystreams#Page', routePrefix: 'as')]
+class Page extends Object_
+PHP
+            , $page);
     }
 
     public function testGenerationWithoutConfigFileQuestion(): void

--- a/tests/config/activity-streams.yaml
+++ b/tests/config/activity-streams.yaml
@@ -1,5 +1,5 @@
 vocabularies:
-    - tests/data/activitystreams2.owl
+    - { uri: tests/data/activitystreams2.owl, apiResourceArguments: [routePrefix: 'as'] }
 vocabularyNamespace: http://www.w3.org/ns/activitystreams#
 allTypes: true
 types:

--- a/tests/e2e/schema.yml
+++ b/tests/e2e/schema.yml
@@ -23,7 +23,8 @@ types:
             collection:
                 get:
                     route_name: get_person_collection
-        security: "is_granted('ROLE_USER')"
+        apiResourceArguments:
+            security: "is_granted('ROLE_USER')"
         properties:
             familyName: ~
             givenName: ~
@@ -32,7 +33,7 @@ types:
             address: { range: https://schema.org/PostalAddress }
             birthDate: ~
             telephone: ~
-            email: { unique: true, security: "is_granted('ROLE_ADMIN')" }
+            email: { unique: true, apiPropertyArguments: [security: "is_granted('ROLE_ADMIN')"] }
             url: ~
             siblings: { cardinality: "(0..*)" }
             knowsAbout: { range: https://schema.org/Thing }


### PR DESCRIPTION
It adds the possibility to add custom `ApiResource` arguments for a specific vocabulary.
The `security` property has been removed since the same behavior can be done by using either `apiPropertyArguments` or `apiResourceArguments` properties.
Type `apiResourceArguments` property has a higher priority than vocabulary `apiResourceArguments` property.