### PR TITLE
DoctrineOrmAttributeGenerator - dateTime resolving to datetime not date type

### DIFF
--- a/src/AttributeGenerator/DoctrineOrmAttributeGenerator.php
+++ b/src/AttributeGenerator/DoctrineOrmAttributeGenerator.php
@@ -108,8 +108,11 @@ final class DoctrineOrmAttributeGenerator extends AbstractAttributeGenerator
                 case 'time':
                     $type = 'time';
                     break;
-                case 'dateTime':
+                case 'date':
                     $type = 'date';
+                    break;
+                case 'dateTime':
+                    $type = 'datetime';
                     break;
                 default:
                     $type = $phpType;
@@ -124,7 +127,7 @@ final class DoctrineOrmAttributeGenerator extends AbstractAttributeGenerator
                             $type = 'text';
                             break;
                         case '\\'.\DateTimeInterface::class:
-                            $type = 'date';
+                            $type = 'datetime';
                             break;
                         case '\\'.\DateInterval::class:
                             $type = 'string';

--- a/tests/e2e/original/App/OpenApi/Entity/Book.php
+++ b/tests/e2e/original/App/OpenApi/Entity/Book.php
@@ -76,7 +76,7 @@ class Book
      *
      * @see https://schema.org/dateCreated
      */
-    #[ORM\Column(type: 'date')]
+    #[ORM\Column(type: 'datetime')]
     #[ApiProperty(types: ['https://schema.org/dateCreated'])]
     #[Assert\Type(\DateTimeInterface::class)]
     #[Assert\NotNull]
@@ -101,7 +101,7 @@ class Book
     #[ApiProperty]
     private ?string $cover = null;
 
-    #[ORM\Column(type: 'date', nullable: true)]
+    #[ORM\Column(type: 'datetime', nullable: true)]
     #[ApiProperty]
     #[Assert\Type(\DateTimeInterface::class)]
     private ?\DateTimeInterface $archivedAt = null;

--- a/tests/e2e/original/App/OpenApi/Entity/Order.php
+++ b/tests/e2e/original/App/OpenApi/Entity/Order.php
@@ -33,7 +33,7 @@ class Order
     #[Assert\NotNull]
     private int $quantity;
 
-    #[ORM\Column(type: 'date')]
+    #[ORM\Column(type: 'datetime')]
     #[ApiProperty]
     #[Assert\Type(\DateTimeInterface::class)]
     #[Assert\NotNull]

--- a/tests/e2e/original/App/OpenApi/Entity/Review.php
+++ b/tests/e2e/original/App/OpenApi/Entity/Review.php
@@ -78,7 +78,7 @@ class Review
     /**
      * Publication date of the review.
      */
-    #[ORM\Column(type: 'date', nullable: true)]
+    #[ORM\Column(type: 'datetime', nullable: true)]
     #[ApiProperty]
     #[Assert\Type(\DateTimeInterface::class)]
     private ?\DateTimeInterface $publicationDate = null;


### PR DESCRIPTION

`DateTime` type is resolved to Doctrine ORM `date` type by attribute generator, what I think is a bit unexpected (?). 

```yaml
# config/schema.yaml
(...)
      createdAt:
        range: "https://schema.org/DateTime"
```

gives:

```php
(...)
    #[ORM\Column(type: 'date', nullable: true)]
    #[Assert\Type(\DateTimeInterface::class)]
    private ?\DateTimeInterface $createdAt = null;
```

instead:

```php
    #[ORM\Column(type: 'datetime', nullable: true)]
    #[Assert\Type(\DateTimeInterface::class)]
    private ?\DateTimeInterface $createdAt = null;
```