### PR TITLE
feat: repeatable attributes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0
+
+* feat: repeatable attributes support
+
 ## 5.0.0
 
 * feat: add OpenAPI support

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,7 +18,7 @@ parameters:
                 required: ?boolean,
                 unique: boolean,
                 embedded: boolean,
-                attributes: array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]|null>
+                attributes: list<array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]|null>>
             }
         '''
         TypeConfiguration: '''
@@ -28,7 +28,7 @@ parameters:
                 abstract: ?boolean,
                 embeddable: boolean,
                 namespaces: array{class: ?string, interface: ?string},
-                attributes: array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]|null>,
+                attributes: list<array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]|null>>,
                 parent: false|string,
                 guessFrom: string,
                 operations: array<string, ?array<string, string|int|bool|string[]|null>>,
@@ -38,7 +38,7 @@ parameters:
         '''
         Configuration: '''
             array{
-                 vocabularies: array{uri: string, format: string, allTypes: ?boolean, attributes: array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]|null>}[],
+                 vocabularies: array{uri: string, format: string, allTypes: ?boolean, attributes: list<array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]|null>>}[],
                  vocabularyNamespace: string,
                  relations: array{uris: string[], defaultCardinality: string},
                  debug: boolean,
@@ -53,7 +53,7 @@ parameters:
                      useCollection: boolean,
                      resolveTargetEntityConfigPath: ?string,
                      resolveTargetEntityConfigType: 'XML'|'yaml',
-                     inheritanceAttributes: array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]>,
+                     inheritanceAttributes: list<array<string, (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal)[]|null>>,
                      inheritanceType: 'JOINED'|'SINGLE_TABLE'|'SINGLE_COLLECTION'|'TABLE_PER_CLASS'|'COLLECTION_PER_CLASS'|'NONE',
                      maxIdentifierLength: integer
                  },

--- a/src/AttributeGenerator/ConfigurationAttributeGenerator.php
+++ b/src/AttributeGenerator/ConfigurationAttributeGenerator.php
@@ -26,16 +26,39 @@ final class ConfigurationAttributeGenerator extends AbstractAttributeGenerator
      */
     public function generateClassAttributes(Class_ $class): array
     {
-        $typeConfig = $this->config['types'][$class->name()] ?? null;
-        $vocabConfig = null;
+        $typeAttributes = $this->config['types'][$class->name()]['attributes'] ?? [[]];
+        $vocabAttributes = [[]];
         if ($class instanceof SchemaClass) {
-            $vocabConfig = $this->config['vocabularies'][$class->resource()->getGraph()->getUri()] ?? null;
+            $vocabAttributes = $this->config['vocabularies'][$class->resource()->getGraph()->getUri()]['attributes'] ?? [[]];
         }
 
+        $getAttributesNames = fn (array $config) => $config === [[]]
+            ? []
+            : array_unique(array_map(fn (array $v) => array_keys($v)[0], $config));
+        $typeAttributesNames = $getAttributesNames($typeAttributes);
+        $vocabAttributesNames = $getAttributesNames($vocabAttributes);
+
+        $getAttribute = fn (string $name, $args) => new Attribute(
+            $name,
+            (\is_array($args) ? $args : [$args]) + [
+                'alwaysGenerate' => !\in_array($name, $vocabAttributesNames, true) ||
+                    \in_array($name, $typeAttributesNames, true),
+                'mergeable' => false,
+            ]
+        );
+
         $attributes = [];
-        $configAttributes = array_merge($vocabConfig['attributes'] ?? [], $typeConfig['attributes'] ?? []);
-        foreach ($configAttributes as $attributeName => $attributeArgs) {
-            $attributes[] = new Attribute($attributeName, ($attributeArgs ?? []) + ['alwaysGenerate' => !isset($vocabConfig['attributes'][$attributeName]) || isset($typeConfig['attributes'][$attributeName])]);
+        foreach ($vocabAttributes as $configAttributes) {
+            foreach ($configAttributes ?? [] as $attributeName => $attributeArgs) {
+                if (!\in_array($attributeName, $typeAttributesNames, true)) {
+                    $attributes[] = $getAttribute($attributeName, $attributeArgs ?? []);
+                }
+            }
+        }
+        foreach ($typeAttributes as $configAttributes) {
+            foreach ($configAttributes ?? [] as $attributeName => $attributeArgs) {
+                $attributes[] = $getAttribute($attributeName, $attributeArgs ?? []);
+            }
         }
 
         return $attributes;
@@ -47,11 +70,16 @@ final class ConfigurationAttributeGenerator extends AbstractAttributeGenerator
     public function generatePropertyAttributes(Property $property, string $className): array
     {
         $typeConfig = $this->config['types'][$className] ?? null;
-        $propertyConfig = $typeConfig['properties'][$property->name()] ?? null;
+        $propertyAttributes = $typeConfig['properties'][$property->name()]['attributes'] ?? [[]];
 
         $attributes = [];
-        foreach ($propertyConfig['attributes'] ?? [] as $attributeName => $attributeArgs) {
-            $attributes[] = new Attribute($attributeName, $attributeArgs ?? []);
+        foreach ($propertyAttributes as $configAttributes) {
+            foreach ($configAttributes ?? [] as $attributeName => $attributeArgs) {
+                $attributes[] = new Attribute(
+                    $attributeName,
+                    ($attributeArgs ?? []) + ['mergeable' => false]
+                );
+            }
         }
 
         return $attributes;

--- a/src/AttributeGenerator/DoctrineMongoDBAttributeGenerator.php
+++ b/src/AttributeGenerator/DoctrineMongoDBAttributeGenerator.php
@@ -40,8 +40,10 @@ final class DoctrineMongoDBAttributeGenerator extends AbstractAttributeGenerator
 
         $attributes = [];
         if ($class->hasChild && ($inheritanceAttributes = $this->config['doctrine']['inheritanceAttributes'])) {
-            foreach ($inheritanceAttributes as $attributeName => $attributeArgs) {
-                $attributes[] = new Attribute($attributeName, $attributeArgs);
+            foreach ($inheritanceAttributes as $configAttributes) {
+                foreach ($configAttributes as $attributeName => $attributeArgs) {
+                    $attributes[] = new Attribute($attributeName, $attributeArgs ?? []);
+                }
             }
         } elseif ($class->isAbstract) {
             $attributes[] = new Attribute('MongoDB\MappedSuperclass');

--- a/src/AttributeGenerator/DoctrineOrmAttributeGenerator.php
+++ b/src/AttributeGenerator/DoctrineOrmAttributeGenerator.php
@@ -48,8 +48,10 @@ final class DoctrineOrmAttributeGenerator extends AbstractAttributeGenerator
 
         $attributes = [];
         if ($class->hasChild && ($inheritanceAttributes = $this->config['doctrine']['inheritanceAttributes'])) {
-            foreach ($inheritanceAttributes as $attributeName => $attributeArgs) {
-                $attributes[] = new Attribute($attributeName, $attributeArgs);
+            foreach ($inheritanceAttributes as $configAttributes) {
+                foreach ($configAttributes as $attributeName => $attributeArgs) {
+                    $attributes[] = new Attribute($attributeName, $attributeArgs ?? []);
+                }
             }
         } elseif ($class->isAbstract) {
             $attributes[] = new Attribute('ORM\MappedSuperclass');

--- a/src/Model/AddAttributeTrait.php
+++ b/src/Model/AddAttributeTrait.php
@@ -18,8 +18,8 @@ trait AddAttributeTrait
     public function addAttribute(Attribute $attribute): self
     {
         if (!\in_array($attribute, $this->attributes, true)) {
-            $curAttribute = $this->getAttributeWithName($attribute->name());
-            if (!$curAttribute || !$curAttribute->mergeable) {
+            $previousAttribute = $this->getAttributeWithName($attribute->name());
+            if (!$previousAttribute || !$previousAttribute->mergeable) {
                 if ($attribute->append) {
                     $this->attributes[] = $attribute;
                 }

--- a/src/Model/AddAttributeTrait.php
+++ b/src/Model/AddAttributeTrait.php
@@ -18,14 +18,19 @@ trait AddAttributeTrait
     public function addAttribute(Attribute $attribute): self
     {
         if (!\in_array($attribute, $this->attributes, true)) {
-            if (!$this->getAttributeWithName($attribute->name())) {
+            $curAttribute = $this->getAttributeWithName($attribute->name());
+            if (!$curAttribute || !$curAttribute->mergeable) {
                 if ($attribute->append) {
                     $this->attributes[] = $attribute;
                 }
             } else {
                 $this->attributes = array_map(
                     fn (Attribute $attr) => $attr->name() === $attribute->name()
-                        ? new Attribute($attr->name(), array_merge($attr->args(), $attribute->args()))
+                        ? new Attribute($attr->name(), array_merge(
+                            $attr->args(),
+                            $attribute->args(),
+                            ['mergeable' => $attribute->mergeable]
+                        ))
                         : $attr,
                     $this->attributes
                 );

--- a/src/Model/Attribute.php
+++ b/src/Model/Attribute.php
@@ -28,6 +28,14 @@ final class Attribute
     public bool $append = true;
 
     /**
+     * Custom explicitly configured attributes is not mergeable with next one
+     * but treated as repeated if given more than once.
+     *
+     * @see ApiPlatform\SchemaGenerator\Model\AddAttributeTrait
+     */
+    public bool $mergeable = true;
+
+    /**
      * @param (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal|\Nette\PhpGenerator\Literal[])[] $args
      */
     public function __construct(string $name, array $args = [])
@@ -35,7 +43,9 @@ final class Attribute
         $this->name = $name;
 
         $this->append = (bool) ($args['alwaysGenerate'] ?? true);
-        unset($args['alwaysGenerate']);
+        $this->mergeable = (bool) ($args['mergeable'] ?? true);
+
+        unset($args['alwaysGenerate'], $args['mergeable']);
 
         $this->args = $args;
     }

--- a/src/Model/Attribute.php
+++ b/src/Model/Attribute.php
@@ -25,13 +25,17 @@ final class Attribute
     /** @var (int|bool|null|string|string[]|string[][]|\Nette\PhpGenerator\Literal|\Nette\PhpGenerator\Literal[])[] */
     private array $args;
 
+    /**
+     * If this attribute can be appended if a same one has not previously been generated or if the same one is not mergeable?
+     *
+     * @see \ApiPlatform\SchemaGenerator\Model\AddAttributeTrait
+     */
     public bool $append = true;
 
     /**
-     * Custom explicitly configured attributes is not mergeable with next one
-     * but treated as repeated if given more than once.
+     * If this attribute mergeable with the next one?
      *
-     * @see ApiPlatform\SchemaGenerator\Model\AddAttributeTrait
+     * @see \ApiPlatform\SchemaGenerator\Model\AddAttributeTrait
      */
     public bool $mergeable = true;
 

--- a/src/SchemaGeneratorConfiguration.php
+++ b/src/SchemaGeneratorConfiguration.php
@@ -49,13 +49,11 @@ final class SchemaGeneratorConfiguration implements ConfigurationInterface
         $namespacePrefix = $this->defaultPrefix ?? 'App\\';
 
         /* @see https://yaml.org/type/omap.html */
-        $transformOmap = fn (array $nodeConfig) => !empty(array_filter(
-            $nodeConfig,
-            fn ($v, $k) => \is_int($k) && \is_array($v) && 1 === \count($v) && \is_string(array_keys($v)[0]),
-            \ARRAY_FILTER_USE_BOTH
-        ))
-            ? array_reduce(array_values($nodeConfig), fn (array $map, array $v) => $map + $v, [])
-            : $nodeConfig;
+        $transformOmap = fn (array $nodeConfig) => array_map(
+            fn ($v, $k) => \is_int($k) ? $v : [$k => $v],
+            array_values($nodeConfig),
+            array_keys($nodeConfig)
+        );
 
         // @phpstan-ignore-next-line node is not null
         $attributesNode = fn () => (new NodeBuilder())

--- a/tests/AttributeGenerator/ConfigurationAttributeGeneratorTest.php
+++ b/tests/AttributeGenerator/ConfigurationAttributeGeneratorTest.php
@@ -45,17 +45,18 @@ class ConfigurationAttributeGeneratorTest extends TestCase
 
         yield 'type configuration' => [
             $class,
-            ['types' => ['Foo' => ['attributes' => ['ApiResource' => ['routePrefix' => '/prefix']]]]],
-            [new Attribute('ApiResource', ['routePrefix' => '/prefix'])],
+            ['types' => ['Foo' => ['attributes' => [['ApiResource' => ['routePrefix' => '/prefix']]]]]],
+            [new Attribute('ApiResource', ['routePrefix' => '/prefix', 'mergeable' => false])],
         ];
 
         $class = new SchemaClass('Foo', new RdfResource('https://schema.org/Foo', new RdfGraph(SchemaGeneratorConfiguration::SCHEMA_ORG_URI)));
         $expectedAttribute = new Attribute('ApiResource', ['routePrefix' => '/prefix']);
         $expectedAttribute->append = false;
+        $expectedAttribute->mergeable = false;
 
         yield 'vocab configuration' => [
             $class,
-            ['vocabularies' => [SchemaGeneratorConfiguration::SCHEMA_ORG_URI => ['attributes' => ['ApiResource' => ['routePrefix' => '/prefix']]]]],
+            ['vocabularies' => [SchemaGeneratorConfiguration::SCHEMA_ORG_URI => ['attributes' => [['ApiResource' => ['routePrefix' => '/prefix']]]]]],
             [$expectedAttribute],
         ];
 
@@ -64,10 +65,10 @@ class ConfigurationAttributeGeneratorTest extends TestCase
         yield 'vocab and type configuration' => [
             $class,
             [
-                'vocabularies' => [SchemaGeneratorConfiguration::SCHEMA_ORG_URI => ['attributes' => ['ApiResource' => ['routePrefix' => '/prefix']]]],
-                'types' => ['Foo' => ['attributes' => ['ApiResource' => ['security' => "is_granted('ROLE_USER')"]]]],
+                'vocabularies' => [SchemaGeneratorConfiguration::SCHEMA_ORG_URI => ['attributes' => [['ApiResource' => ['routePrefix' => '/prefix']]]]],
+                'types' => ['Foo' => ['attributes' => [['ApiResource' => ['security' => "is_granted('ROLE_USER')"]]]]],
             ],
-            [new Attribute('ApiResource', ['security' => "is_granted('ROLE_USER')"])],
+            [new Attribute('ApiResource', ['security' => "is_granted('ROLE_USER')", 'mergeable' => false])],
         ];
     }
 
@@ -89,8 +90,8 @@ class ConfigurationAttributeGeneratorTest extends TestCase
 
         yield 'type configuration' => [
             $property,
-            ['types' => ['Res' => ['properties' => ['prop' => ['attributes' => ['ApiResource' => ['security' => "is_granted('ROLE_USER')"]]]]]]],
-            [new Attribute('ApiResource', ['security' => "is_granted('ROLE_USER')"])],
+            ['types' => ['Res' => ['properties' => ['prop' => ['attributes' => [['ApiResource' => ['security' => "is_granted('ROLE_USER')"]]]]]]]],
+            [new Attribute('ApiResource', ['security' => "is_granted('ROLE_USER')", 'mergeable' => false])],
         ];
     }
 

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -102,6 +102,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 #[ORM\Entity]
 #[ApiResource(types: ['https://schema.org/Book'], routePrefix: '/library')]
+#[ORM\UniqueConstraint(name: 'isbn', columns: ['isbn'])]
+#[ORM\UniqueConstraint(name: 'title', columns: ['title'])]
 #[MyAttribute]
 class Book
 {
@@ -115,6 +117,17 @@ PHP
             , $book);
         $this->assertStringContainsString(<<<'PHP'
     #[ORM\OrderBy(name: 'ASC')]
+PHP
+            , $book);
+        // Generated attribute could be merged with next one that is a configured one.
+        $this->assertStringContainsString(<<<'PHP'
+    #[ORM\InverseJoinColumn(nullable: false, unique: true, name: 'first_join_column')]
+PHP
+            , $book);
+        // Configured attribute could not be merged with next one and it is treated
+        // as repeated.
+        $this->assertStringContainsString(<<<'PHP'
+    #[ORM\InverseJoinColumn(name: 'second_join_column')]
 PHP
             , $book);
     }

--- a/tests/config/custom-attributes.yaml
+++ b/tests/config/custom-attributes.yaml
@@ -5,6 +5,8 @@ types:
     attributes:
       - ORM\Entity: ~
       - ApiResource: { routePrefix: '/library' }
+      - ORM\UniqueConstraint: { name: "isbn", columns: ["isbn"] }
+      - ORM\UniqueConstraint: { name: "title", columns: ["title"] }
       - MyAttribute: ~
     properties:
       isbn: ~
@@ -17,6 +19,11 @@ types:
         attributes:
           ORM\OneToMany: { cascade: [persist, remove] }
           ORM\OrderBy: { name: ASC }
+          0:
+            ORM\InverseJoinColumn: { name: "first_join_column" }
+          1:
+            ORM\InverseJoinColumn: { name: "second_join_column" }
+
   Review:
     properties:
       book:

--- a/tests/e2e/customized/App/Schema/Entity/Person.php
+++ b/tests/e2e/customized/App/Schema/Entity/Person.php
@@ -35,6 +35,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     security: 'is_granted(\'ROLE_USER\')',
 )]
 #[UniqueEntity('email')]
+#[UniqueEntity('givenName', 'familyName')]
 #[MyCustomAttribute(foo: 'bar')]
 class Person extends MyCustomClass implements MyCustomInterface
 {

--- a/tests/e2e/original/App/Schema/Entity/Person.php
+++ b/tests/e2e/original/App/Schema/Entity/Person.php
@@ -31,7 +31,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     security: 'is_granted(\'ROLE_USER\')',
 )]
-#[UniqueEntity('email')]
+#[UniqueEntity('email', 'givenName')]
+#[UniqueEntity('familyName')]
 class Person extends Thing
 {
     /**

--- a/tests/e2e/schema.yml
+++ b/tests/e2e/schema.yml
@@ -23,6 +23,10 @@ types:
             ORM\Entity: ~
             ApiResource:
                 security: "is_granted('ROLE_USER')"
+            0:
+                UniqueEntity: ['givenName']
+            1:
+                UniqueEntity: ['familyName']
         properties:
             familyName: ~
             givenName: ~


### PR DESCRIPTION
Support for repeatable attributes, for example:

```yaml
Book:
    attributes:
      - ORM\UniqueConstraint: { name: "isbn", columns: ["isbn"] }
      - ORM\UniqueConstraint: { name: "title", columns: ["title"] }
   properties:
      isbn: ~
      title: { range: "https://schema.org/Text" }
```

gives:

```php
/**
 * A book.
 *
 * @see https://schema.org/Book
 */
#[ORM\Entity]
#[ApiResource(types: ['https://schema.org/Book'], routePrefix: '/library')]
#[ORM\UniqueConstraint(name: 'isbn', columns: ['isbn'])]
#[ORM\UniqueConstraint(name: 'title', columns: ['title'])]
#[MyAttribute]
class Book
{
```
