### PR TITLE
Replace inactive URL in GOOD_RELATIONS_URI

### DIFF
--- a/src/SchemaGeneratorConfiguration.php
+++ b/src/SchemaGeneratorConfiguration.php
@@ -31,7 +31,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 final class SchemaGeneratorConfiguration implements ConfigurationInterface
 {
     public const SCHEMA_ORG_URI = 'https://schema.org/version/latest/schemaorg-current-https.rdf';
-    public const GOOD_RELATIONS_URI = 'https://archive.org/services/purl/goodrelations/v1.owl';
+    public const GOOD_RELATIONS_URI = 'https://www.heppnetz.de/ontologies/goodrelations/v1.owl';
     public const SCHEMA_ORG_NAMESPACE = 'https://schema.org/';
 
     private ?string $defaultPrefix;

--- a/tests/Command/DumpConfigurationTest.php
+++ b/tests/Command/DumpConfigurationTest.php
@@ -56,10 +56,10 @@ config:
     relations:
 
         # OWL relation URIs containing cardinality information in the GoodRelations format
-        uris:                 # Example: 'https://archive.org/services/purl/goodrelations/v1.owl'
+        uris:                 # Example: 'https://www.heppnetz.de/ontologies/goodrelations/v1.owl'
 
             # Default:
-            - https://archive.org/services/purl/goodrelations/v1.owl
+            - https://www.heppnetz.de/ontologies/goodrelations/v1.owl
 
         # The default cardinality to use when it cannot be extracted
         defaultCardinality:   (1..1) # One of "(0..1)"; "(0..*)"; "(1..1)"; "(1..*)"; "(*..0)"; "(*..1)"; "(*..*)"


### PR DESCRIPTION
Fix for https://github.com/api-platform/schema-generator/issues/428

pure.org has been unavailable for some time. After outage of archive.org, used URL is broken. Official URL is on heppnetz.de according to https://github.com/mfhepp/goodrelations/issues/1
