### PR TITLE
generate setter for simple arrays option

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -61,6 +61,7 @@ parameters:
                  author: false|string,
                  fieldVisibility: 'private'|'protected'|'public'|null,
                  accessorMethods: boolean,
+                 useSimpleArraySetter: boolean,
                  fluentMutatorMethods: boolean,
                  rangeMapping: array<string, string>,
                  allTypes: boolean,

--- a/src/Model/Class_.php
+++ b/src/Model/Class_.php
@@ -218,6 +218,7 @@ abstract class Class_
     {
         $useDoctrineCollections = $config['doctrine']['useCollection'];
         $useAccessors = $config['accessorMethods'];
+        $useSimpleArraySetter = $config['useSimpleArraySetter'];
         $useFluentMutators = $config['fluentMutatorMethods'];
         $fileHeader = $config['header'] ?? null;
         $fieldVisibility = $config['fieldVisibility'];
@@ -333,7 +334,7 @@ abstract class Class_
             foreach ($sortedProperties as $property) {
                 foreach ($property->generateNetteMethods(static function ($string) use ($inflector) {
                     return $inflector->singularize($string)[0];
-                }, $namespace, $useDoctrineCollections, $useFluentMutators) as $method) {
+                }, $namespace, $useDoctrineCollections, $useFluentMutators, $useSimpleArraySetter) as $method) {
                     $methods[] = $method;
                 }
             }

--- a/src/SchemaGeneratorConfiguration.php
+++ b/src/SchemaGeneratorConfiguration.php
@@ -167,6 +167,7 @@ final class SchemaGeneratorConfiguration implements ConfigurationInterface
                 ->scalarNode('author')->defaultFalse()->info('The value of the phpDoc\'s @author annotation')->example('Kévin Dunglas <dunglas@gmail.com>')->end()
                 ->enumNode('fieldVisibility')->values(['private', 'protected', 'public'])->defaultValue('private')->cannotBeEmpty()->info('Visibility of entities fields')->end()
                 ->booleanNode('accessorMethods')->defaultTrue()->info('Set this flag to false to not generate getter, setter, adder and remover methods')->end()
+                ->booleanNode('useSimpleArraySetter')->defaultFalse()->info('Set this flag to true to generate setter method for simple arrays instead of adder and remover methods')->end()
                 ->booleanNode('fluentMutatorMethods')->defaultFalse()->info('Set this flag to true to generate fluent setter, adder and remover methods')->end()
                 ->arrayNode('rangeMapping')
                     ->useAttributeAsKey('name')

--- a/tests/Command/DumpConfigurationTest.php
+++ b/tests/Command/DumpConfigurationTest.php
@@ -154,6 +154,9 @@ config:
     # Set this flag to false to not generate getter, setter, adder and remover methods
     accessorMethods:      true
 
+    # Set this flag to true to generate setter method for simple arrays instead of adder and remover methods
+    useSimpleArraySetter: false
+
     # Set this flag to true to generate fluent setter, adder and remover methods
     fluentMutatorMethods: false
     rangeMapping:
@@ -275,8 +278,7 @@ config:
     generatorTemplates:   []
 
 
-YAML
-            ,
+YAML,
             $commandTester->getDisplay()
         );
     }

--- a/tests/Command/ExtractCardinalitiesCommandTest.php
+++ b/tests/Command/ExtractCardinalitiesCommandTest.php
@@ -1475,7 +1475,6 @@ class ExtractCardinalitiesCommandTest extends TestCase
     "https:\/\/schema.org\/mainEntityOfPage": "unknown"
 }
 
-JSON
-            , $commandTester->getDisplay());
+JSON, $commandTester->getDisplay());
     }
 }

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -70,8 +70,7 @@ class GenerateCommandTest extends TestCase
     {
         return $this->friends;
     }
-PHP
-            , $person);
+PHP, $person);
     }
 
     public function testCustomAttributes(): void
@@ -106,29 +105,24 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[MyAttribute]
 class Book
 {
-PHP
-            , $book);
+PHP, $book);
 
         // Attributes given as unordered map.
         $this->assertStringContainsString(<<<'PHP'
     #[ORM\OneToMany(targetEntity: 'App\Entity\Review', mappedBy: 'book', cascade: ['persist', 'remove'])]
-PHP
-            , $book);
+PHP, $book);
         $this->assertStringContainsString(<<<'PHP'
     #[ORM\OrderBy(name: 'ASC')]
-PHP
-            , $book);
+PHP, $book);
         // Generated attribute could be merged with next one that is a configured one.
         $this->assertStringContainsString(<<<'PHP'
     #[ORM\InverseJoinColumn(nullable: false, unique: true, name: 'first_join_column')]
-PHP
-            , $book);
+PHP, $book);
         // Configured attribute could not be merged with next one and it is treated
         // as repeated.
         $this->assertStringContainsString(<<<'PHP'
     #[ORM\InverseJoinColumn(name: 'second_join_column')]
-PHP
-            , $book);
+PHP, $book);
     }
 
     public function testFluentMutators(): void
@@ -147,8 +141,7 @@ PHP
 
         return $this;
     }
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringContainsString(<<<'PHP'
     public function addFriend(Person $friend): self
@@ -164,8 +157,7 @@ PHP
 
         return $this;
     }
-PHP
-            , $person);
+PHP, $person);
     }
 
     public function testDoNotGenerateAccessorMethods(): void
@@ -230,8 +222,7 @@ PHP
 
         $this->assertStringContainsString(<<<'PHP'
     private string $availability = 'https://schema.org/InStock';
-PHP
-            , $book);
+PHP, $book);
     }
 
     public function testReadableWritable(): void
@@ -274,16 +265,14 @@ PHP
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(type: 'integer')]
     private ?int $id = null;
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringContainsString(<<<'PHP'
     public function getId(): ?int
     {
         return $this->id;
     }
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringNotContainsString('setId(', $person);
     }
@@ -304,24 +293,21 @@ PHP
     #[ORM\Id]
     #[ORM\Column(type: 'string')]
     private string $id;
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringContainsString(<<<'PHP'
     public function getId(): string
     {
         return $this->id;
     }
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringContainsString(<<<'PHP'
     public function setId(string $id): void
     {
         $this->id = $id;
     }
-PHP
-            , $person);
+PHP, $person);
     }
 
     public function testGeneratedUuid(): void
@@ -342,16 +328,14 @@ PHP
     #[ORM\Column(type: 'guid')]
     #[Assert\Uuid]
     private ?string $id = null;
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringContainsString(<<<'PHP'
     public function getId(): ?string
     {
         return $this->id;
     }
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringNotContainsString('setId(', $person);
     }
@@ -373,16 +357,14 @@ PHP
     #[ORM\Column(type: 'guid')]
     #[Assert\Uuid]
     private string $id;
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringContainsString(<<<'PHP'
     public function getId(): string
     {
         return $this->id;
     }
-PHP
-            , $person);
+PHP, $person);
 
         $this->assertStringContainsString(<<<'PHP'
     public function setId(string $id): void
@@ -390,8 +372,7 @@ PHP
         $this->id = $id;
     }
 
-PHP
-            , $person);
+PHP, $person);
     }
 
     public function testDoNotGenerateId(): void
@@ -463,8 +444,7 @@ PHP
         $this->assertStringContainsString(<<<'PHP'
     /** @var string The female gender. */
     public const FEMALE = 'https://schema.org/Female';
-PHP
-            , $gender);
+PHP, $gender);
 
         $this->assertStringNotContainsString('function setId(', $gender);
     }
@@ -490,8 +470,7 @@ PHP
     #[ORM\Column(type: 'text', nullable: true)]
     #[ApiProperty(types: ['https://schema.org/award'])]
     private ?string $award = null;
-PHP
-            , $creativeWork);
+PHP, $creativeWork);
 
         $this->assertStringNotContainsString('protected', $creativeWork);
     }
@@ -517,8 +496,7 @@ PHP
     #[ORM\Column(type: 'text', nullable: true, name: '`content`')]
     #[ApiProperty(types: ['http://www.w3.org/ns/activitystreams#content'])]
     private ?string $content = null;
-PHP
-            , $object);
+PHP, $object);
 
         $page = file_get_contents("$outputDir/App/Entity/Page.php");
 
@@ -531,11 +509,45 @@ PHP
 #[ORM\Entity]
 #[ApiResource(types: ['http://www.w3.org/ns/activitystreams#Page'], routePrefix: 'as')]
 class Page extends Object_
-PHP
-            , $page);
+PHP, $page);
 
         self::assertFalse($this->fs->exists("$outputDir/App/Entity/Delete.php"));
         self::assertFalse($this->fs->exists("$outputDir/App/Entity/Travel.php"));
+    }
+
+    public function testGeneratedSimpleArray(): void
+    {
+        $outputDir = __DIR__.'/../../build/simple-array';
+        $config = __DIR__.'/../config/simple-array.yaml';
+
+        $this->fs->mkdir($outputDir);
+
+        $commandTester = new CommandTester(new GenerateCommand());
+        $this->assertEquals(0, $commandTester->execute(['output' => $outputDir, 'config' => $config]));
+        $source = file_get_contents("$outputDir/App/Entity/Project.php");
+
+        $this->assertStringContainsString(<<<'PHP'
+    /**
+     * @see _:shareWith
+     */
+    #[ORM\Column(type: 'simple_array', nullable: true)]
+    #[Assert\Unique]
+    private ?array $shareWith = [];
+PHP, $source);
+
+        $this->assertStringContainsString(<<<'PHP'
+    public function setShareWith(?array $shareWith): void
+    {
+        $this->shareWith = $shareWith;
+    }
+
+    public function getShareWith(): ?array
+    {
+        return $this->shareWith;
+    }
+PHP, $source);
+        $this->assertStringNotContainsString('function addShareWith', $source);
+        $this->assertStringNotContainsString('function removeShareWith', $source);
     }
 
     public function testGenerationWithoutConfigFileQuestion(): void

--- a/tests/TypesGeneratorTest.php
+++ b/tests/TypesGeneratorTest.php
@@ -105,7 +105,7 @@ class TypesGeneratorTest extends TestCase
         $article = file_get_contents("$this->outputDir/App/Entity/Article.php");
         $this->assertStringContainsString('abstract class Article extends CreativeWork', $article);
         $this->assertStringContainsString('private ?string $articleBody = null;', $article);
-        $this->assertStringContainsString('private array $articleSection = [];', $article);
+        $this->assertStringContainsString('private ?array $articleSection = [];', $article);
         $this->assertStringContainsString('public function setArticleBody(?string $articleBody): void', $article);
         $this->assertStringContainsString('public function getArticleBody(): ?string', $article);
         $this->assertStringContainsString('public function addArticleSection(string $articleSection): void', $article);

--- a/tests/config/simple-array.yaml
+++ b/tests/config/simple-array.yaml
@@ -1,0 +1,12 @@
+useSimpleArraySetter: true
+types:
+  Project:
+    properties:
+      name:
+        range: "https://schema.org/Text"
+      shareWith:
+        range: "https://schema.org/email"
+        cardinality: "(0..*)"
+        attributes:
+          Assert\Unique: ~
+          ORM\Column: { type: "simple_array" }

--- a/tests/e2e/customized/App/Schema/Enum/GenderType.php
+++ b/tests/e2e/customized/App/Schema/Enum/GenderType.php
@@ -13,9 +13,9 @@ use MyCLabs\Enum\Enum;
  */
 class GenderType extends Enum
 {
-    /** @var string The male gender. */
-    public const MALE = 'https://schema.org/Male';
-
     /** @var string The female gender. */
     public const FEMALE = 'https://schema.org/Female';
+
+    /** @var string The male gender. */
+    public const MALE = 'https://schema.org/Male';
 }

--- a/tests/e2e/original/App/Schema/Entity/Person.php
+++ b/tests/e2e/original/App/Schema/Entity/Person.php
@@ -63,7 +63,7 @@ class Person extends Thing
     private ?string $additionalName = null;
 
     /**
-     * Gender of something, typically a \[\[Person\]\], but possibly also fictional characters, animals, etc. While https://schema.org/Male and https://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender. The \[\[gender\]\] property can also be used in an extended sense to cover e.g. the gender of sports teams. As with the gender of individuals, we do not try to enumerate all possibilities. A mixed-gender \[\[SportsTeam\]\] can be indicated with a text value of "Mixed".
+     * Gender of something, typically a \[\[Person\]\], but possibly also fictional characters, animals, etc. While https://schema.org/Male and https://schema.org/Female may be used, text strings are also acceptable for people who are not a binary gender. The \[\[gender\]\] property can also be used in an extended sense to cover e.g. the gender of sports teams. As with the gender of individuals, we do not try to enumerate all possibilities. A mixed-gender \[\[SportsTeam\]\] can be indicated with a text value of "Mixed".
      *
      * @see https://schema.org/gender
      */

--- a/tests/e2e/original/App/Schema/Enum/GenderType.php
+++ b/tests/e2e/original/App/Schema/Enum/GenderType.php
@@ -13,9 +13,9 @@ use MyCLabs\Enum\Enum;
  */
 class GenderType extends Enum
 {
-    /** @var string The male gender. */
-    public const MALE = 'https://schema.org/Male';
-
     /** @var string The female gender. */
     public const FEMALE = 'https://schema.org/Female';
+
+    /** @var string The male gender. */
+    public const MALE = 'https://schema.org/Male';
 }


### PR DESCRIPTION
Generate setter method instead of adder and remover for simple arrays option  for  backward compatibility turned off by default. 

Having  adder and remover denormalization of simple arrays needs  usage of reflection based PropertyNormalizer to keep sent keys (to reset keys in fact), because array  can't be just replaced with new one using entity interface and this is needed for proper item indexing in validation message and json serialization for example on Mercure pushes usage (arrays are serialized as json object not as arrays), ex:

```
curl -X 'GET' \
  'https://localhost/projects/642969' \
  -H 'accept: application/ld+json'
{
  "@context": "/contexts/Project",
  "@id": "/projects/642969",
  // ...
  "shareWith": [
    "test@example.com"
  ]
}

curl -X 'PATCH' \
  'https://localhost/projects/642969' \
  -H 'accept: application/ld+json' \
  -H 'Content-Type: application/merge-patch+json' \
  -d '{
  "shareWith": [
    "test3@"
  ]
}'
{
  "@context": "/contexts/ConstraintViolationList",
  "@id": "/validation_errors/bd79c0ab-ddba-46cc-a703-a7a4b08de310",
  "@type": "ConstraintViolationList",
  "status": 422,
  "violations":
    {
      "propertyPath": "shareWith[1]", // <-- should be 0 as it is serialized in GET
      "message": "This value is not a valid email address.",
      "code": "bd79c0ab-ddba-46cc-a703-a7a4b08de310"
    }
  ],
```
If valid value is sent (ex. 'test3@example.com') and it is used in mercure push it is serialized as  json object `{"1":  "test1@example.com"}`  in request body however on the frontend site by OpenApi/ Hydra docs we expects  an array so without custom handling it crash on array operations (ex. `project.shareWith.map(//...)`).
