### PR TITLE
Remove deprecation and older version support for nette/php-generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "twig/twig": "^3.0",
-        "nette/php-generator": "^3.6 || ^4.0",
+        "nette/php-generator": "^4.1.7",
         "nikic/php-parser": "^4.13 || ^5.0",
         "devizzent/cebe-php-openapi": "^1.0.3",
         "symfony/string": "^5.4 || ^6.4 || ^7.0 || ^8.0",

--- a/src/Model/Constant.php
+++ b/src/Model/Constant.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\SchemaGenerator\Model;
 
-use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Constant as NetteConstant;
+use Nette\PhpGenerator\Visibility;
 
 abstract class Constant
 {
@@ -49,7 +49,7 @@ abstract class Constant
     {
         $constant = (new NetteConstant($this->name))
             ->setValue($this->value())
-            ->setVisibility(ClassType::VISIBILITY_PUBLIC);
+            ->setVisibility(Visibility::Public);
 
         foreach ($this->annotations as $annotation) {
             $constant->addComment($annotation);

--- a/src/Model/Property.php
+++ b/src/Model/Property.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\SchemaGenerator\Model;
 
 use ApiPlatform\SchemaGenerator\Model\Type\ArrayType;
 use ApiPlatform\SchemaGenerator\Model\Type\Type;
-use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\Property as NetteProperty;
@@ -214,7 +213,7 @@ abstract class Property
             throw new \LogicException(\sprintf("Property '%s' is not readable.", $this->name));
         }
 
-        $getter = (new Method('get'.ucfirst($this->name)))->setVisibility(ClassType::VISIBILITY_PUBLIC);
+        $getter = (new Method('get'.ucfirst($this->name)))->setVisibility(Visibility::Public);
         foreach ($this->getterAnnotations as $annotation) {
             $getter->addComment($annotation);
         }
@@ -247,7 +246,7 @@ abstract class Property
         if ($this->isArray() && (!$this->isSimpleArray() || !$useSimpleArraySetter)) {
             $singularProperty = $singularize($this->name());
 
-            $adder = (new Method('add'.ucfirst($singularProperty)))->setVisibility(ClassType::VISIBILITY_PUBLIC);
+            $adder = (new Method('add'.ucfirst($singularProperty)))->setVisibility(Visibility::Public);
             $adder->setReturnType($useFluentMutators ? 'self' : 'void');
             foreach ($this->adderAnnotations() as $annotation) {
                 $adder->addComment($annotation);
@@ -265,7 +264,7 @@ abstract class Property
             }
             $mutators[] = $adder;
 
-            $remover = (new Method('remove'.ucfirst($singularProperty)))->setVisibility(ClassType::VISIBILITY_PUBLIC);
+            $remover = (new Method('remove'.ucfirst($singularProperty)))->setVisibility(Visibility::Public);
             $remover->setReturnType($useFluentMutators ? 'self' : 'void');
             foreach ($this->removerAnnotations as $annotation) {
                 $adder->addComment($annotation);
@@ -297,7 +296,7 @@ PHP,
 
             $mutators[] = $remover;
         } else {
-            $setter = (new Method('set'.ucfirst($this->name())))->setVisibility(ClassType::VISIBILITY_PUBLIC);
+            $setter = (new Method('set'.ucfirst($this->name())))->setVisibility(Visibility::Public);
             $setter->setReturnType($useFluentMutators ? 'self' : 'void');
             foreach ($this->setterAnnotations as $annotation) {
                 $setter->addComment($annotation);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Nette's `Visibility` class is already used in the abstract `Property` class [here](https://github.com/api-platform/schema-generator/blob/77f1ca56380dc76529fdcf27bac3904efcb0fe07/src/Model/Property.php#L156), so this means that support for `nette/php-generator` 3 can be dropped, since the `Visibility` class was added in `v4.1.7` (commit here: https://github.com/nette/php-generator/commit/a5711b37c40939faa67915c657f7599c5c45bd65 ).
Also, `nette/php-generator` 3 is not supported anymore since 2022 as of [its latest release](https://github.com/nette/php-generator/releases/tag/v3.6.9)